### PR TITLE
refactor: remove redundant `+1` offset in `NestedSetsBehavior` class in `shiftLeftRightAttribute` calls.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -142,7 +142,7 @@ class NestedSetsBehavior extends Behavior
         $rightValue = $this->getOwner()->getAttribute($this->rightAttribute);
 
         if ($this->operation === self::OPERATION_DELETE_WITH_CHILDREN || $this->getOwner()->isLeaf()) {
-            $this->shiftLeftRightAttribute($rightValue + 1, $leftValue - $rightValue - 1);
+            $this->shiftLeftRightAttribute($rightValue, $leftValue - $rightValue - 1);
         } else {
             $condition = [
                 'and',
@@ -1276,7 +1276,7 @@ class NestedSetsBehavior extends Behavior
                     ],
                 ],
             );
-            $this->shiftLeftRightAttribute($rightValue + 1, $leftValue - $rightValue - 1);
+            $this->shiftLeftRightAttribute($rightValue, $leftValue - $rightValue - 1);
         }
     }
 
@@ -1332,7 +1332,7 @@ class NestedSetsBehavior extends Behavior
                 ],
             ],
         );
-        $this->shiftLeftRightAttribute($rightValue + 1, $leftValue - $rightValue - 1);
+        $this->shiftLeftRightAttribute($rightValue, $leftValue - $rightValue - 1);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
