### PR TITLE
refactor: Streamline node movement logic in `NestedSetsBehavior` class in `afterUpdate()` method.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -247,22 +247,19 @@ class NestedSetsBehavior extends Behavior
      */
     public function afterUpdate(): void
     {
-        switch (true) {
-            case $this->operation === self::OPERATION_APPEND_TO && $this->node !== null:
-                $this->moveNode($this->node, $this->node->getAttribute($this->rightAttribute), 1);
-                break;
-            case $this->operation === self::OPERATION_INSERT_AFTER && $this->node !== null:
-                $this->moveNode($this->node, $this->node->getAttribute($this->rightAttribute) + 1, 0);
-                break;
-            case $this->operation === self::OPERATION_INSERT_BEFORE && $this->node !== null:
-                $this->moveNode($this->node, $this->node->getAttribute($this->leftAttribute), 0);
-                break;
-            case $this->operation === self::OPERATION_MAKE_ROOT:
-                $this->moveNodeAsRoot();
-                break;
-            case $this->operation === self::OPERATION_PREPEND_TO && $this->node !== null:
-                $this->moveNode($this->node, $this->node->getAttribute($this->leftAttribute) + 1, 1);
-        }
+        match (true) {
+            $this->operation === self::OPERATION_APPEND_TO && $this->node !== null =>
+                $this->moveNode($this->node, $this->node->getAttribute($this->rightAttribute), 1),
+            $this->operation === self::OPERATION_INSERT_AFTER && $this->node !== null =>
+                $this->moveNode($this->node, $this->node->getAttribute($this->rightAttribute) + 1, 0),
+            $this->operation === self::OPERATION_INSERT_BEFORE && $this->node !== null =>
+                $this->moveNode($this->node, $this->node->getAttribute($this->leftAttribute), 0),
+            $this->operation === self::OPERATION_MAKE_ROOT =>
+                $this->moveNodeAsRoot(),
+            $this->operation === self::OPERATION_PREPEND_TO && $this->node !== null =>
+                $this->moveNode($this->node, $this->node->getAttribute($this->leftAttribute) + 1, 1),
+            default => null,
+        };
 
         $this->operation = null;
         $this->node = null;

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1159,7 +1159,7 @@ class NestedSetsBehavior extends Behavior
      * @param int $value Left attribute value indicating the new position for the node.
      * @param int $depth Depth offset to apply to the node and its descendants after the move.
      */
-    protected function moveNode(ActiveRecord $node, $value, int $depth): void
+    protected function moveNode(ActiveRecord $node, int $value, int $depth): void
     {
         $db = $this->getOwner()::getDb();
         $leftValue = $this->getOwner()->getAttribute($this->leftAttribute);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of node updates for nested sets, resulting in more explicit and reliable node movement operations. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->