### PR TITLE
refactor: Remove unnecessary node refresh in `beforeInsert()` method of `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -363,10 +363,6 @@ class NestedSetsBehavior extends Behavior
      */
     public function beforeInsert(): void
     {
-        if ($this->node?->getIsNewRecord() === false) {
-            $this->node->refresh();
-        }
-
         $nodeLeftValue = $this->node?->getAttribute($this->leftAttribute) ?? 0;
         $nodeRightValue = $this->node?->getAttribute($this->rightAttribute) ?? 0;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

