### PR TITLE
refactor: Remove redundant offset in `shiftLeftRightAttribute` call in `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -174,7 +174,7 @@ class NestedSetsBehavior extends Behavior
                 ],
                 $condition,
             );
-            $this->shiftLeftRightAttribute($rightValue + 1, -2);
+            $this->shiftLeftRightAttribute($rightValue, -2);
         }
 
         $this->operation = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of nested set node deletions, ensuring more accurate updates to the structure after a node is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->