### PR TITLE
refactor: Remove unnecessary node refresh in `delete()` method of `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -328,8 +328,6 @@ class NestedSetsBehavior extends Behavior
                 'Method "' . get_class($this->getOwner()) . '::delete" is not supported for deleting root nodes.',
             );
         }
-
-        $this->getOwner()->refresh();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the deletion process for nested sets by removing unnecessary data refresh operations, resulting in a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->