### PR TITLE
refactor: Remove unnecessary node refresh in `beforeUpdate()` method of `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -412,10 +412,6 @@ class NestedSetsBehavior extends Behavior
      */
     public function beforeUpdate(): void
     {
-        if ($this->node?->getIsNewRecord() === false) {
-            $this->node->refresh();
-        }
-
         switch ($this->operation) {
             case self::OPERATION_MAKE_ROOT:
                 if ($this->treeAttribute === false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the update process for nested set nodes by removing an unnecessary data refresh step, resulting in more efficient operations. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->