### PR TITLE
refactor: Validate `non-null` value for `right` attribute in `beforeInsertNode()` method of `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1049,10 +1049,12 @@ class NestedSetsBehavior extends Behavior
             throw new Exception('Can not create a node when the target node is root.');
         }
 
-        if ($value !== null) {
-            $this->getOwner()->setAttribute($this->leftAttribute, $value);
-            $this->getOwner()->setAttribute($this->rightAttribute, $value + 1);
+        if ($value === null) {
+            throw new Exception('Value cannot be \'null\' in \'beforeInsertNode()\' method.');
         }
+
+        $this->getOwner()->setAttribute($this->leftAttribute, $value);
+        $this->getOwner()->setAttribute($this->rightAttribute, $value + 1);
 
         $nodeDepthValue = $this->node?->getAttribute($this->depthAttribute) ?? 0;
 
@@ -1062,7 +1064,7 @@ class NestedSetsBehavior extends Behavior
             $this->getOwner()->setAttribute($this->treeAttribute, $this->node->getAttribute($this->treeAttribute));
         }
 
-        $this->shiftLeftRightAttribute($value ?? 0, 2);
+        $this->shiftLeftRightAttribute($value, 2);
     }
 
     /**

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1719,4 +1719,65 @@ final class NestedSetsBehaviorTest extends TestCase
             self::fail('Real insertion failed: ' . $e->getMessage());
         }
     }
+
+    public function testReturnShiftedLeftRightAttributesWhenChildAppendedToRoot(): void
+    {
+        $this->createDatabase();
+
+        $root = new Tree(['name' => 'Root']);
+
+        $root->makeRoot();
+
+        $child = new Tree(['name' => 'Child']);
+
+        $child->appendTo($root);
+
+        self::assertEquals(
+            1,
+            $root->lft,
+            'Root node left value should be \'1\' after \'makeRoot\' and appending a child.',
+        );
+        self::assertEquals(
+            4,
+            $root->rgt,
+            'Root node right value should be \'4\' after \'makeRoot\' and appending a child.',
+        );
+        self::assertEquals(
+            2,
+            $child->lft,
+            'Child node left value should be \'2\' after being appended to the root node.',
+        );
+        self::assertEquals(
+            3,
+            $child->rgt,
+            'Child node right value should be \'3\' after being appended to the root node.',
+        );
+        self::assertNotEquals(
+            0,
+            $child->lft,
+            'Child node left value should not be \'0\' after \'appendTo\' operation.',
+        );
+        self::assertNotEquals(
+            1,
+            $child->rgt,
+            'Child node right value should not be \'1\' after \'appendTo\' operation.',
+        );
+    }
+
+    public function testThrowExceptionWhenAppendToParentWithNullRightValue(): void
+    {
+        $this->createDatabase();
+
+        $parentNode = new Tree(['name' => 'Parent Node']);
+
+        $parentNode->makeRoot();
+        $parentNode->setAttribute('rgt', null);
+
+        $childNode = new Tree(['name' => 'Child Node']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Value cannot be \'null\' in \'beforeInsertNode()\' method.');
+
+        $childNode->appendTo($parentNode);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
