### PR TITLE
refactor: Update save logic in `NestedSetsBehavior` class to refresh node after saving. Add test for `left` and `right` attribute adjustment when appending child to root.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -297,7 +297,10 @@ class NestedSetsBehavior extends Behavior
         $this->node = $node;
 
         $result = $this->getOwner()->save($runValidation, $attributes);
-        $node->refresh();
+
+        if ($result === true) {
+            $node->refresh();
+        }
 
         return $result;
     }

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -296,7 +296,10 @@ class NestedSetsBehavior extends Behavior
         $this->operation = self::OPERATION_APPEND_TO;
         $this->node = $node;
 
-        return $this->getOwner()->save($runValidation, $attributes);
+        $result = $this->getOwner()->save($runValidation, $attributes);
+        $node->refresh();
+
+        return $result;
     }
 
     /**

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1720,6 +1720,50 @@ final class NestedSetsBehaviorTest extends TestCase
         }
     }
 
+    public function testReturnShiftedLeftRightAttributesWhenChildAppendedToRoot(): void
+    {
+        $this->createDatabase();
+
+        $root = new Tree(['name' => 'Root']);
+
+        $root->makeRoot();
+
+        $child = new Tree(['name' => 'Child']);
+
+        $child->appendTo($root);
+
+        self::assertEquals(
+            1,
+            $root->lft,
+            'Root node left value should be \'1\' after \'makeRoot\' and appending a child.',
+        );
+        self::assertEquals(
+            4,
+            $root->rgt,
+            'Root node right value should be \'4\' after \'makeRoot\' and appending a child.',
+        );
+        self::assertEquals(
+            2,
+            $child->lft,
+            'Child node left value should be \'2\' after being appended to the root node.',
+        );
+        self::assertEquals(
+            3,
+            $child->rgt,
+            'Child node right value should be \'3\' after being appended to the root node.',
+        );
+        self::assertNotEquals(
+            0,
+            $child->lft,
+            'Child node left value should not be \'0\' after \'appendTo\' operation.',
+        );
+        self::assertNotEquals(
+            1,
+            $child->rgt,
+            'Child node right value should not be \'1\' after \'appendTo\' operation.',
+        );
+    }
+
     public function testThrowExceptionWhenAppendToParentWithNullRightValue(): void
     {
         $this->createDatabase();

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1727,10 +1727,12 @@ final class NestedSetsBehaviorTest extends TestCase
         $root = new Tree(['name' => 'Root']);
 
         $root->makeRoot();
+        $root->refresh();
 
         $child = new Tree(['name' => 'Child']);
 
         $child->appendTo($root);
+        $child->refresh();
 
         self::assertEquals(
             1,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when appending a node by ensuring the target node is refreshed after a successful operation, keeping its state up to date.

* **Tests**
  * Added a new test to verify correct left and right attribute values when a child node is appended to the root node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->