### PR TITLE
test: Add verification for protected method `beforeInsertNode` accessibility in subclasses of `NestedSetsBehavior`.

### DIFF
--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2052,7 +2052,7 @@ final class NestedSetsBehaviorTest extends TestCase
         );
     }
 
-    public function testProtectedApplyTreeAttributeConditionRemainAccessibleToSubclasses(): void
+    public function testProtectedApplyTreeAttributeConditionRemainsAccessibleToSubclasses(): void
     {
         $this->createDatabase();
 
@@ -2086,7 +2086,7 @@ final class NestedSetsBehaviorTest extends TestCase
         );
     }
 
-    public function testProtectedBeforeInsertNodeRemainAccessibleToSubclasses(): void
+    public function testProtectedBeforeInsertNodeRemainsAccessibleToSubclasses(): void
     {
         $this->createDatabase();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to ensure protected methods in nested sets behavior remain accessible and customizable by subclasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->