### PR TITLE
test: Add verification for leaves method ordering in `NestedSetsQueryBehaviorTest`.

### DIFF
--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1719,7 +1719,7 @@ final class NestedSetsBehaviorTest extends TestCase
             self::assertEquals(
                 1,
                 $child->depth,
-                'Child node depth should be \'1\' after being appended to the root node.',
+                'Child node depth should be \'1\' after being \'appendTo\' the root node.',
             );
         } catch (Exception $e) {
             self::fail('Real insertion failed: ' . $e->getMessage());
@@ -1753,12 +1753,12 @@ final class NestedSetsBehaviorTest extends TestCase
         self::assertEquals(
             2,
             $child->lft,
-            'Child node left value should be \'2\' after being appended to the root node.',
+            'Child node left value should be \'2\' after being \'appendTo\' to the root node.',
         );
         self::assertEquals(
             3,
             $child->rgt,
-            'Child node right value should be \'3\' after being appended to the root node.',
+            'Child node right value should be \'3\' after being \'appendTo\' the root node.',
         );
         self::assertNotEquals(
             0,
@@ -1979,26 +1979,26 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $persistedNode,
-            'Node should exist in database after makeRoot with validation disabled.',
+            'Node should exist in database after \'makeRoot\' with validation disabled.',
         );
         self::assertTrue(
             $persistedNode->isRoot(),
-            'Node should be a root node after makeRoot operation.',
+            'Node should be a root node after \'makeRoot\' operation.',
         );
         self::assertEquals(
             1,
             $persistedNode->lft,
-            'Root node should have left value of 1.',
+            'Root node should have left value of \'1\'.',
         );
         self::assertEquals(
             2,
             $persistedNode->rgt,
-            'Root node should have right value of 2.',
+            'Root node should have right value of \'2\'.',
         );
         self::assertEquals(
             0,
             $persistedNode->depth,
-            'Root node should have depth of 0.',
+            'Root node should have depth of \'0\'.',
         );
     }
 
@@ -2021,7 +2021,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertFalse(
             $resultWithValidation,
-            "\'prependTo()\' with \'runValidation=true\' should return \'false\' when validation fails.",
+            '\'prependTo()\' with \'runValidation=true\' should return \'false\' when validation fails.',
         );
         self::assertTrue(
             $hasError1,
@@ -2310,13 +2310,14 @@ final class NestedSetsBehaviorTest extends TestCase
             self::assertInstanceOf(
                 Tree::class,
                 $child,
-                "Child at index {$index} should be an instance of \'Tree\'.",
+                "Child at index {$index} should be an instance of 'Tree'.",
             );
+
             if (isset($expectedOrder[$index])) {
                 self::assertEquals(
                     $expectedOrder[$index],
                     $child->getAttribute('name'),
-                    "Child at index {$index} should be {$expectedOrder[$index]} in correct \'lft\' order.",
+                    "Child at index {$index} should be {$expectedOrder[$index]} in correct 'lft' order.",
                 );
             }
         }

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -623,7 +623,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $node,
-            'Node with ID \'9\' must exist before attempting to append to a node in another tree.',
+            'Node with ID \'9\' must exist before attempting to \'appendTo()\' a node in another tree.',
         );
 
         $node->name = 'Updated node 2';
@@ -632,7 +632,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $childOfNode,
-            'Target node with ID \'53\' must exist before attempting to append to it.',
+            'Target node with ID \'53\' must exist before attempting to \'appendTo()\' it.',
         );
 
         self::assertTrue(
@@ -719,7 +719,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $node,
-            'Node with ID \'9\' must exist before calling insertBefore() on another node.',
+            'Node with ID \'9\' must exist before calling \'insertBefore()\' on another node.',
         );
 
         $node->name = 'Updated node 2';
@@ -728,7 +728,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $childOfNode,
-            'Target node with ID \'2\' must exist before calling insertBefore() on it.',
+            'Target node with ID \'2\' must exist before calling \'insertBefore()\' on it.',
         );
         self::assertTrue(
             $node->insertBefore($childOfNode),
@@ -739,7 +739,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $node,
-            'Node with ID \'31\' must exist before calling insertBefore() on another node.',
+            'Node with ID \'31\' must exist before calling \'insertBefore()\' on another node.',
         );
 
         $node->name = 'Updated node 2';
@@ -748,11 +748,11 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $childOfNode,
-            'Target node with ID \'24\' must exist before calling insertBefore() on it.',
+            'Target node with ID \'24\' must exist before calling \'insertBefore()\' on it.',
         );
         self::assertTrue(
             $node->insertBefore($childOfNode),
-            'insertBefore() should return true when moving node \'31\' before node \'24\' in MultipleTree.',
+            '\'insertBefore()\' should return \'true\' when moving node \'31\' before node \'24\' in \'MultipleTree\'.',
         );
 
         $simpleXML = $this->loadFixtureXML('test-insert-before-exists-up.xml');
@@ -760,7 +760,7 @@ final class NestedSetsBehaviorTest extends TestCase
         self::assertEquals(
             $this->buildFlatXMLDataSet($this->getDataSet()),
             $simpleXML->asXML(),
-            'Resulting dataset after insertBefore() must match the expected XML structure.',
+            'Resulting dataset after \'insertBefore()\' must match the expected XML structure.',
         );
     }
 
@@ -772,7 +772,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $node,
-            'Node with ID \'9\' should exist before calling insertBefore() on another node.',
+            'Node with ID \'9\' should exist before calling \'insertBefore()\' on another node.',
         );
 
         $node->name = 'Updated node 2';
@@ -781,18 +781,18 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $childOfNode,
-            'Target node with ID \'16\' should exist before calling insertBefore() on it.',
+            'Target node with ID \'16\' should exist before calling \'insertBefore()\' on it.',
         );
         self::assertTrue(
             $node->insertBefore($childOfNode),
-            'insertBefore() should return true when moving node \'9\' before node \'16\' in Tree.',
+            '\'insertBefore()\' should return \'true\' when moving node \'9\' before node \'16\' in \'Tree\'.',
         );
 
         $node = MultipleTree::findOne(31);
 
         self::assertNotNull(
             $node,
-            'Node with ID \'31\' should exist before calling insertBefore() on another node.',
+            'Node with ID \'31\' should exist before calling \'insertBefore()\' on another node.',
         );
 
         $node->name = 'Updated node 2';
@@ -801,11 +801,11 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertNotNull(
             $childOfNode,
-            'Target node with ID \'38\' should exist before calling insertBefore() on it.',
+            'Target node with ID \'38\' should exist before calling \'insertBefore()\' on it.',
         );
         self::assertTrue(
             $node->insertBefore($childOfNode),
-            'insertBefore() should return true when moving node \'31\' before node \'38\' in MultipleTree.',
+            '\'insertBefore()\' should return \'true\' when moving node \'31\' before node \'38\' in \'MultipleTree\'.',
         );
 
         $simpleXML = $this->loadFixtureXML('test-insert-before-exists-down.xml');
@@ -813,7 +813,7 @@ final class NestedSetsBehaviorTest extends TestCase
         self::assertEquals(
             $this->buildFlatXMLDataSet($this->getDataSet()),
             $simpleXML->asXML(),
-            'Resulting dataset after insertBefore() must match the expected XML structure.',
+            'Resulting dataset after \'insertBefore()\' must match the expected XML structure.',
         );
     }
 

--- a/tests/NestedSetsQueryBehaviorTest.php
+++ b/tests/NestedSetsQueryBehaviorTest.php
@@ -111,13 +111,80 @@ final class NestedSetsQueryBehaviorTest extends TestCase
             self::assertInstanceOf(
                 MultipleTree::class,
                 $root,
-                "Root at index {$index} should be an instance of \'MultipleTree\'.",
+                "Root at index {$index} should be an instance of 'MultipleTree'.",
             );
+
             if (isset($expectedOrder[$index])) {
                 self::assertEquals(
                     $expectedOrder[$index],
                     $root->getAttribute('name'),
-                    "Root at index {$index} should be {$expectedOrder[$index]} in correct \'tree\' order.",
+                    "Root at index {$index} should be {$expectedOrder[$index]} in correct 'tree' order.",
+                );
+            }
+        }
+    }
+
+    public function testLeavesMethodRequiresLeftAttributeOrderingForConsistentResults(): void
+    {
+        $this->createDatabase();
+
+        $root = new MultipleTree(['name' => 'Root']);
+
+        $root->makeRoot();
+
+        $leaf1 = new MultipleTree(['name' => 'Leaf A']);
+
+        $leaf1->appendTo($root);
+
+        $leaf2 = new MultipleTree(['name' => 'Leaf B']);
+
+        $leaf2->appendTo($root);
+
+        $initialLeaves = MultipleTree::find()->leaves()->all();
+
+        self::assertCount(
+            2,
+            $initialLeaves,
+            'Should have exactly \'2\' initial leaf nodes.',
+        );
+
+        $command = $this->getDb()->createCommand();
+
+        $command->update('multiple_tree', ['lft' => 3, 'rgt' => 4], ['name' => 'Leaf B'])->execute();
+        $command->update('multiple_tree', ['lft' => 5, 'rgt' => 6], ['name' => 'Leaf A'])->execute();
+        $command->update('multiple_tree', ['lft' => 1, 'rgt' => 7], ['name' => 'Root'])->execute();
+
+        $leaves = MultipleTree::find()->leaves()->all();
+
+        /** @phpstan-var array<array{name: string, lft: int}> */
+        $expectedLeaves = [
+            ['name' => 'Leaf B', 'lft' => 3],
+            ['name' => 'Leaf A', 'lft' => 5],
+        ];
+
+        self::assertCount(
+            2,
+            $leaves,
+            'Should return exactly \'2\' leaf nodes.',
+        );
+
+        foreach ($leaves as $index => $leaf) {
+            self::assertInstanceOf(
+                MultipleTree::class,
+                $leaf,
+                "Leaf at index {$index} should be an instance of 'MultipleTree'.",
+            );
+
+            if (isset($expectedLeaves[$index])) {
+                self::assertEquals(
+                    $expectedLeaves[$index]['name'],
+                    $leaf->getAttribute('name'),
+                    "Leaf at index {$index} should be {$expectedLeaves[$index]['name']} in correct order.",
+                );
+                self::assertEquals(
+                    $expectedLeaves[$index]['lft'],
+                    $leaf->getAttribute('lft'),
+                    "Leaf at index {$index} should have left value {$expectedLeaves[$index]['lft']}.",
                 );
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved clarity and consistency of assertion failure messages in nested set behavior tests.
  * Added a new test to verify that leaf nodes are consistently ordered by their left attribute when using the leaves method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->