### PR TITLE
fix: Correct `left`-`right` attribute shifting logic in `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1250,7 +1250,7 @@ class NestedSetsBehavior extends Behavior
                 );
             }
 
-            $this->shiftLeftRightAttribute($rightValue + 1, -$delta);
+            $this->shiftLeftRightAttribute($rightValue, -$delta);
         } else {
             $leftAttribute = $db->quoteColumnName($this->leftAttribute);
             $rightAttribute = $db->quoteColumnName($this->rightAttribute);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
