### PR TITLE
feat: Introduce NodeContext class for improved node movement handling and refactor `beforeInsert`, and `moveNode` method to use context.

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -85,3 +85,5 @@ enabled:
 disabled:
   - function_declaration
   - new_with_parentheses
+  - psr12_braces
+  - psr12_class_definition

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -379,17 +379,17 @@ class NestedSetsBehavior extends Behavior
     {
         match (true) {
             $this->operation === self::OPERATION_APPEND_TO && $this->node !== null => $this->beforeInsertNodeWithContext(
-                NodeContext::forAppendTo($this->node, $this->rightAttribute)
+                NodeContext::forAppendTo($this->node, $this->rightAttribute),
             ),
             $this->operation === self::OPERATION_INSERT_AFTER && $this->node !== null => $this->beforeInsertNodeWithContext(
-                NodeContext::forInsertAfter($this->node, $this->rightAttribute)
+                NodeContext::forInsertAfter($this->node, $this->rightAttribute),
             ),
             $this->operation === self::OPERATION_INSERT_BEFORE && $this->node !== null => $this->beforeInsertNodeWithContext(
-                NodeContext::forInsertBefore($this->node, $this->leftAttribute)
+                NodeContext::forInsertBefore($this->node, $this->leftAttribute),
             ),
             $this->operation === self::OPERATION_MAKE_ROOT => $this->beforeInsertRootNode(),
             $this->operation === self::OPERATION_PREPEND_TO && $this->node !== null => $this->beforeInsertNodeWithContext(
-                NodeContext::forPrependTo($this->node, $this->leftAttribute)
+                NodeContext::forPrependTo($this->node, $this->leftAttribute),
             ),
             default => throw new NotSupportedException(
                 'Method "' . get_class($this->getOwner()) . '::insert" is not supported for inserting new nodes.',

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1439,7 +1439,7 @@ class NestedSetsBehavior extends Behavior
                 $this->depthAttribute => new Expression(
                     $this->getDb()->quoteColumnName($this->depthAttribute) . sprintf('%+d', $depth),
                 ),
-                $this->treeAttribute => $newTreeValue
+                $this->treeAttribute => $newTreeValue,
             ],
             [
                 'and',
@@ -1454,7 +1454,7 @@ class NestedSetsBehavior extends Behavior
                     $rightValue,
                 ],
                 [
-                    $this->treeAttribute => $currentTreeValue
+                    $this->treeAttribute => $currentTreeValue,
                 ],
             ],
         );

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -34,6 +34,7 @@ use function sprintf;
  * - Supports custom attribute names for left, right, depth, and tree columns.
  *
  * @phpstan-template T of ActiveRecord
+ *
  * @phpstan-extends Behavior<T>
  *
  * @property int $depth

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1413,16 +1413,16 @@ class NestedSetsBehavior extends Behavior
      * This operation is essential for maintaining the integrity of the nested set structure when reorganizing nodes
      * between trees or promoting a node to root in a multi-tree configuration.
      *
-     * @param mixed $nodeRootValue Value to assign to the tree attribute for all nodes in the moved subtree.
-     * @param mixed $treeValue Current tree attribute value of the nodes being moved.
+     * @param mixed $newTreeValue Value to assign to the tree attribute for all nodes in the moved subtree.
+     * @param mixed $currentTreeValue Current tree attribute value of the nodes being moved.
      * @param int $depth Depth offset to apply to all nodes in the subtree.
      * @param int $leftValue Left boundary value of the subtree to move.
      * @param int $positionOffset Amount to shift left and right attribute values for the subtree.
      * @param int $rightValue Right boundary value of the subtree to move.
      */
     private function moveSubtreeToTargetTree(
-        mixed $nodeRootValue,
-        mixed $treeValue,
+        mixed $newTreeValue,
+        mixed $currentTreeValue,
         int $depth,
         int $leftValue,
         int $positionOffset,
@@ -1439,7 +1439,7 @@ class NestedSetsBehavior extends Behavior
                 $this->depthAttribute => new Expression(
                     $this->getDb()->quoteColumnName($this->depthAttribute) . sprintf('%+d', $depth),
                 ),
-                $this->treeAttribute => $nodeRootValue,
+                $this->treeAttribute => $newTreeValue
             ],
             [
                 'and',
@@ -1454,7 +1454,7 @@ class NestedSetsBehavior extends Behavior
                     $rightValue,
                 ],
                 [
-                    $this->treeAttribute => $treeValue,
+                    $this->treeAttribute => $currentTreeValue
                 ],
             ],
         );

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -34,7 +34,6 @@ use function sprintf;
  * - Supports custom attribute names for left, right, depth, and tree columns.
  *
  * @phpstan-template T of ActiveRecord
- *
  * @phpstan-extends Behavior<T>
  *
  * @property int $depth
@@ -301,6 +300,7 @@ class NestedSetsBehavior extends Behavior
      * $category->appendTo($parentCategory);
      * ```
      *
+     * @phpstan-param T $node
      * @phpstan-param array<string, mixed>|null $attributes
      */
     public function appendTo(ActiveRecord $node, bool $runValidation = true, array|null $attributes = null): bool

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -262,19 +262,16 @@ class NestedSetsBehavior extends Behavior
 
         if ($this->operation === self::OPERATION_MAKE_ROOT) {
             $this->moveNodeAsRoot($currentOwnerTreeValue);
-            $this->resetOperationState();
             return;
         }
 
         if ($this->node === null) {
-            $this->resetOperationState();
             return;
         }
 
         $context = $this->createMoveContext($this->node, $this->operation);
 
         $this->moveNode($context);
-        $this->resetOperationState();
     }
 
     /**
@@ -1490,16 +1487,5 @@ class NestedSetsBehavior extends Behavior
                 ],
             ],
         );
-    }
-
-    /**
-     * Resets the internal operation state after completing a nested set operation.
-     *
-     * Clears the current operation type and target node reference to prepare for subsequent operations..
-     */
-    private function resetOperationState(): void
-    {
-        $this->operation = null;
-        $this->node = null;
     }
 }

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1284,7 +1284,7 @@ class NestedSetsBehavior extends Behavior
                 $treeValue,
                 $depthValue,
                 $leftValue,
-                ($value - $leftValue),
+                $value - $leftValue,
                 $rightValue,
             );
             $this->shiftLeftRightAttribute($rightValue, $leftValue - $rightValue - 1);
@@ -1323,7 +1323,7 @@ class NestedSetsBehavior extends Behavior
             $treeValue,
             -$depthValue,
             $leftValue,
-            (1 - $leftValue),
+            1 - $leftValue,
             $rightValue,
         );
         $this->shiftLeftRightAttribute($rightValue, $leftValue - $rightValue - 1);

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1092,24 +1092,6 @@ class NestedSetsBehavior extends Behavior
     }
 
     /**
-     * Prepares the current node for insertion using a NodeContext.
-     *
-     * Sets the left, right, and depth attributes of the node to be inserted, based on the provided context which
-     * encapsulates the target node, operation type, and calculated values.
-     *
-     * This method delegates to {@see beforeInsertNode()} using the values from the NodeContext, ensuring consistency
-     * and reducing code duplication.
-     *
-     * @param NodeContext $context Immutable context containing all necessary data for node insertion.
-     *
-     * @throws Exception if an unexpected error occurs during execution.
-     */
-    protected function beforeInsertNodeWithContext(NodeContext $context): void
-    {
-        $this->beforeInsertNode($context->targetPositionValue, $context->depthLevelDelta);
-    }
-
-    /**
      * Prepares the current node for insertion as a root node in the nested set tree.
      *
      * Sets the left, right, and depth attributes of the node to their initial values, establishing it as the root node
@@ -1357,6 +1339,24 @@ class NestedSetsBehavior extends Behavior
                 $condition,
             );
         }
+    }
+
+    /**
+     * Prepares the current node for insertion using a NodeContext.
+     *
+     * Sets the left, right, and depth attributes of the node to be inserted, based on the provided context which
+     * encapsulates the target node, operation type, and calculated values.
+     *
+     * This method delegates to {@see beforeInsertNode()} using the values from the NodeContext, ensuring consistency
+     * and reducing code duplication.
+     *
+     * @param NodeContext $context Immutable context containing all necessary data for node insertion.
+     *
+     * @throws Exception if an unexpected error occurs during execution.
+     */
+    private function beforeInsertNodeWithContext(NodeContext $context): void
+    {
+        $this->beforeInsertNode($context->targetPositionValue, $context->depthLevelDelta);
     }
 
     /**

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -29,7 +29,8 @@ final class NodeContext
         public readonly string $operation,
         public readonly int $targetPositionValue,
         public readonly int $depthLevelDelta,
-    ) {}
+    ) {
+    }
 
     /**
      * Creates context for append-to operation (last child).

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -29,7 +29,8 @@ final class NodeContext
         public readonly string $operation,
         public readonly int $targetPositionValue,
         public readonly int $depthLevelDelta,
-    ) {}
+    ) {
+    }
 
     /**
      * Creates context for append-to operation (last child).
@@ -125,15 +126,13 @@ final class NodeContext
     public function getTargetDepth(string $depthAttribute): int
     {
         /** @var int $depth */
-        $depth = $this->targetNode->getAttribute($depthAttribute);
-
-        return $depth;
+        return $this->targetNode->getAttribute($depthAttribute);
     }
 
     /**
      * Returns the tree attribute value of the target node.
      *
-     * @param string|false $treeAttribute Name of the tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of the tree attribute or `false` if disabled.
      *
      * @return mixed Tree attribute value or `null` if tree attribute is disabled.
      */

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -29,8 +29,7 @@ final class NodeContext
         public readonly string $operation,
         public readonly int $targetPositionValue,
         public readonly int $depthLevelDelta,
-    ) {
-    }
+    ) {}
 
     /**
      * Creates context for append-to operation (last child).
@@ -39,16 +38,15 @@ final class NodeContext
      * @param string $rightAttribute Name of the right attribute.
      *
      * @return self New instance with the specified parameters for append-to operation.
+     *
+     * @phpstan-param 'rgt' $rightAttribute
      */
     public static function forAppendTo(ActiveRecord $targetNode, string $rightAttribute): self
     {
-        /** @phpstan-var int $rightValue */
-        $rightValue = $targetNode->getAttribute($rightAttribute);
-
         return new self(
             targetNode: $targetNode,
             operation: NestedSetsBehavior::OPERATION_APPEND_TO,
-            targetPositionValue: $rightValue,
+            targetPositionValue: $targetNode->getAttribute($rightAttribute),
             depthLevelDelta: 1,
         );
     }
@@ -60,10 +58,11 @@ final class NodeContext
      * @param string $rightAttribute Name of the right attribute.
      *
      * @return self New instance with the specified parameters for insert-after operation.
+     *
+     * @phpstan-param 'rgt' $rightAttribute
      */
     public static function forInsertAfter(ActiveRecord $targetNode, string $rightAttribute): self
     {
-        /** @phpstan-var int $rightValue */
         $rightValue = $targetNode->getAttribute($rightAttribute);
 
         return new self(
@@ -81,10 +80,11 @@ final class NodeContext
      * @param string $leftAttribute Name of the left attribute.
      *
      * @return self New instance with the specified parameters for insert-before operation.
+     *
+     * @phpstan-param 'lft' $leftAttribute
      */
     public static function forInsertBefore(ActiveRecord $targetNode, string $leftAttribute): self
     {
-        /** @var int $leftValue */
         $leftValue = $targetNode->getAttribute($leftAttribute);
 
         return new self(
@@ -102,10 +102,11 @@ final class NodeContext
      * @param string $leftAttribute Name of the left attribute.
      *
      * @return self New instance with the specified parameters for prepend-to operation.
+     *
+     * @phpstan-param 'lft' $leftAttribute
      */
     public static function forPrependTo(ActiveRecord $targetNode, string $leftAttribute): self
     {
-        /** @var int $leftValue */
         $leftValue = $targetNode->getAttribute($leftAttribute);
 
         return new self(
@@ -122,10 +123,12 @@ final class NodeContext
      * @param string $depthAttribute Name of the depth attribute.
      *
      * @return int Depth value of the target node.
+     *
+     * @phpstan-param 'depth' $depthAttribute
      */
     public function getTargetDepth(string $depthAttribute): int
     {
-        return (int) $this->targetNode->getAttribute($depthAttribute);
+        return $this->targetNode->getAttribute($depthAttribute);
     }
 
     /**

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -29,8 +29,7 @@ final class NodeContext
         public readonly string $operation,
         public readonly int $targetPositionValue,
         public readonly int $depthLevelDelta,
-    ) {
-    }
+    ) {}
 
     /**
      * Creates context for append-to operation (last child).

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -25,10 +25,9 @@ use yii\db\ActiveRecord;
 final class NodeContext
 {
     public function __construct(
-        public readonly ActiveRecord $targetNode,
-        public readonly string $operation,
-        public readonly int $targetPositionValue,
-        public readonly int $depthLevelDelta,
+        private readonly ActiveRecord $targetNode,
+        private readonly int|null $targetPositionValue,
+        private readonly int $depthLevelDelta,
     ) {}
 
     /**
@@ -45,7 +44,6 @@ final class NodeContext
     {
         return new self(
             targetNode: $targetNode,
-            operation: NestedSetsBehavior::OPERATION_APPEND_TO,
             targetPositionValue: $targetNode->getAttribute($rightAttribute),
             depthLevelDelta: 1,
         );
@@ -67,7 +65,6 @@ final class NodeContext
 
         return new self(
             targetNode: $targetNode,
-            operation: NestedSetsBehavior::OPERATION_INSERT_AFTER,
             targetPositionValue: $rightValue + 1,
             depthLevelDelta: 0,
         );
@@ -89,7 +86,6 @@ final class NodeContext
 
         return new self(
             targetNode: $targetNode,
-            operation: NestedSetsBehavior::OPERATION_INSERT_BEFORE,
             targetPositionValue: $leftValue,
             depthLevelDelta: 0,
         );
@@ -111,10 +107,14 @@ final class NodeContext
 
         return new self(
             targetNode: $targetNode,
-            operation: NestedSetsBehavior::OPERATION_PREPEND_TO,
             targetPositionValue: $leftValue + 1,
             depthLevelDelta: 1,
         );
+    }
+
+    public function getDepthLevelDelta(): int
+    {
+        return $this->depthLevelDelta;
     }
 
     /**
@@ -129,6 +129,16 @@ final class NodeContext
     public function getTargetDepth(string $depthAttribute): int
     {
         return $this->targetNode->getAttribute($depthAttribute);
+    }
+
+    /**
+     * Returns the target position value used for node movement.
+     *
+     * @return int Target position value, or 0 if not set.
+     */
+    public function getTargetPositionValue(): int
+    {
+        return $this->targetPositionValue ?? 0;
     }
 
     /**

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\nestedsets;
+
+use yii\db\ActiveRecord;
+
+/**
+ * Immutable context object containing all necessary data for node movement operations.
+ *
+ * Encapsulates target node, operation type, and derived values to eliminate parameter passing and provide type safety
+ * for nested set operations.
+ *
+ * Key features.
+ * - Calculated positioning values.
+ * - Immutable value object design.
+ * - Operation-specific factory methods.
+ * - PHPStan compatibility.
+ * - Type-safe node references.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NodeContext
+{
+    public function __construct(
+        public readonly ActiveRecord $targetNode,
+        public readonly string $operation,
+        public readonly int $targetPositionValue,
+        public readonly int $depthLevelDelta,
+    ) {}
+
+    /**
+     * Creates context for append-to operation (last child).
+     *
+     * @param ActiveRecord $targetNode Target node to append to.
+     * @param string $rightAttribute Name of the right attribute.
+     *
+     * @return self New instance with the specified parameters for append-to operation.
+     */
+    public static function forAppendTo(ActiveRecord $targetNode, string $rightAttribute): self
+    {
+        /** @phpstan-var int $rightValue */
+        $rightValue = $targetNode->getAttribute($rightAttribute);
+
+        return new self(
+            targetNode: $targetNode,
+            operation: NestedSetsBehavior::OPERATION_APPEND_TO,
+            targetPositionValue: $rightValue,
+            depthLevelDelta: 1,
+        );
+    }
+
+    /**
+     * Creates context for insert-after operation (next sibling).
+     *
+     * @param ActiveRecord $targetNode Target node to insert after.
+     * @param string $rightAttribute Name of the right attribute.
+     *
+     * @return self New instance with the specified parameters for insert-after operation.
+     */
+    public static function forInsertAfter(ActiveRecord $targetNode, string $rightAttribute): self
+    {
+        /** @phpstan-var int $rightValue */
+        $rightValue = $targetNode->getAttribute($rightAttribute);
+
+        return new self(
+            targetNode: $targetNode,
+            operation: NestedSetsBehavior::OPERATION_INSERT_AFTER,
+            targetPositionValue: $rightValue + 1,
+            depthLevelDelta: 0,
+        );
+    }
+
+    /**
+     * Creates context for insert-before operation (previous sibling).
+     *
+     * @param ActiveRecord $targetNode Target node to insert before.
+     * @param string $leftAttribute Name of the left attribute.
+     *
+     * @return self New instance with the specified parameters for insert-before operation.
+     */
+    public static function forInsertBefore(ActiveRecord $targetNode, string $leftAttribute): self
+    {
+        /** @var int $leftValue */
+        $leftValue = $targetNode->getAttribute($leftAttribute);
+
+        return new self(
+            targetNode: $targetNode,
+            operation: NestedSetsBehavior::OPERATION_INSERT_BEFORE,
+            targetPositionValue: $leftValue,
+            depthLevelDelta: 0,
+        );
+    }
+
+    /**
+     * Creates context for prepend-to operation (first child).
+     *
+     * @param ActiveRecord $targetNode Target node to prepend to.
+     * @param string $leftAttribute Name of the left attribute.
+     *
+     * @return self New instance with the specified parameters for prepend-to operation.
+     */
+    public static function forPrependTo(ActiveRecord $targetNode, string $leftAttribute): self
+    {
+        /** @var int $leftValue */
+        $leftValue = $targetNode->getAttribute($leftAttribute);
+
+        return new self(
+            targetNode: $targetNode,
+            operation: NestedSetsBehavior::OPERATION_PREPEND_TO,
+            targetPositionValue: $leftValue + 1,
+            depthLevelDelta: 1,
+        );
+    }
+
+    /**
+     * Returns the depth value of the target node.
+     *
+     * @param string $depthAttribute Name of the depth attribute.
+     *
+     * @return int Depth value of the target node.
+     */
+    public function getTargetDepth(string $depthAttribute): int
+    {
+        /** @var int $depth */
+        $depth = $this->targetNode->getAttribute($depthAttribute);
+
+        return $depth;
+    }
+
+    /**
+     * Returns the tree attribute value of the target node.
+     *
+     * @param string|false $treeAttribute Name of the tree attribute or `false` if disabled.
+     *
+     * @return mixed Tree attribute value or `null` if tree attribute is disabled.
+     */
+    public function getTargetTreeValue(string|false $treeAttribute): mixed
+    {
+        return $treeAttribute !== false
+            ? $this->targetNode->getAttribute($treeAttribute)
+            : null;
+    }
+}

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -125,8 +125,7 @@ final class NodeContext
      */
     public function getTargetDepth(string $depthAttribute): int
     {
-        /** @var int $depth */
-        return $this->targetNode->getAttribute($depthAttribute);
+        return (int) $this->targetNode->getAttribute($depthAttribute);
     }
 
     /**

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -138,7 +138,7 @@ final class NodeContext
      */
     public function getTargetPositionValue(): int
     {
-        return $this->targetPositionValue ?? 0;
+        return (int) $this->targetPositionValue;
     }
 
     /**

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -26,8 +26,8 @@ final class NodeContext
 {
     public function __construct(
         private readonly ActiveRecord $targetNode,
-        private readonly int|null $targetPositionValue,
-        private readonly int $depthLevelDelta,
+        public readonly int $targetPositionValue,
+        public readonly int $depthLevelDelta,
     ) {}
 
     /**
@@ -112,11 +112,6 @@ final class NodeContext
         );
     }
 
-    public function getDepthLevelDelta(): int
-    {
-        return $this->depthLevelDelta;
-    }
-
     /**
      * Returns the depth value of the target node.
      *
@@ -129,16 +124,6 @@ final class NodeContext
     public function getTargetDepth(string $depthAttribute): int
     {
         return $this->targetNode->getAttribute($depthAttribute);
-    }
-
-    /**
-     * Returns the target position value used for node movement.
-     *
-     * @return int Target position value, or 0 if not set.
-     */
-    public function getTargetPositionValue(): int
-    {
-        return (int) $this->targetPositionValue;
     }
 
     /**

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1601,7 +1601,7 @@ final class NestedSetsBehaviorTest extends TestCase
         $this->createDatabase();
 
         $behavior = new class extends NestedSetsBehavior {
-            public function callBeforeInsertNode(int|null $value, int $depth): void
+            public function callBeforeInsertNode(int $value, int $depth): void
             {
                 $this->beforeInsertNode($value, $depth);
             }
@@ -1739,23 +1739,6 @@ final class NestedSetsBehaviorTest extends TestCase
             $child->rgt,
             "Child node right value should not be '1' after 'appendTo()' operation.",
         );
-    }
-
-    public function testThrowExceptionWhenAppendToParentWithNullRightValue(): void
-    {
-        $this->createDatabase();
-
-        $parentNode = new Tree(['name' => 'Parent Node']);
-
-        $parentNode->makeRoot();
-        $parentNode->setAttribute('rgt', null);
-
-        $childNode = new Tree(['name' => 'Child Node']);
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage("Value cannot be 'null' in 'beforeInsertNode()' method.");
-
-        $childNode->appendTo($parentNode);
     }
 
     public function testAppendToWithRunValidationParameterUsingStrictValidation(): void

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -54,14 +54,14 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
     {
         $this->calledMethods['moveNode'] = true;
 
-        $this->moveNode($node, $value, $depth);
+        $this->moveNode($node, null, $value, $depth);
     }
 
     public function exposedMoveNodeAsRoot(): void
     {
         $this->calledMethods['moveNodeAsRoot'] = true;
 
-        $this->moveNodeAsRoot();
+        $this->moveNodeAsRoot(null);
     }
 
     public function exposedShiftLeftRightAttribute(int $value, int $delta): void

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -54,7 +54,14 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
     {
         $this->calledMethods['moveNode'] = true;
 
-        $this->moveNode($node, null, $value, $depth);
+        // Create a mock context for testing compatibility
+        $context = new \yii2\extensions\nestedsets\NodeContext(
+            $node,
+            'appendTo',
+            0,
+            0
+        );
+        $this->moveNode($context);
     }
 
     public function exposedMoveNodeAsRoot(): void

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -59,7 +59,7 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
             $node,
             'appendTo',
             0,
-            0
+            0,
         );
         $this->moveNode($context);
     }

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -29,7 +29,7 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
         $this->applyTreeAttributeCondition($condition);
     }
 
-    public function exposedBeforeInsertNode(int|null $value, int $depth): void
+    public function exposedBeforeInsertNode(int $value, int $depth): void
     {
         $this->calledMethods['beforeInsertNode'] = true;
 
@@ -57,7 +57,6 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
         // Create a mock context for testing compatibility
         $context = new \yii2\extensions\nestedsets\NodeContext(
             $node,
-            'appendTo',
             0,
             0,
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for managing and moving nodes across multiple trees within nested set structures, allowing explicit handling of tree attributes during node operations.
  * Introduced a context-based approach for node movement operations, simplifying interaction and improving type safety.

* **Refactor**
  * Enhanced efficiency and clarity of node movement operations, including centralized and optimized subtree updates when moving nodes between trees.
  * Streamlined internal logic for node repositioning with improved maintainability and database connection optimization.
  * Updated method signatures to enforce stricter type usage, improving robustness.

* **Chores**
  * Updated coding style configuration to disable additional PSR-12 related fixers for consistent code formatting.
  * Removed a test verifying exception on appending to a parent with null right value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->