### PR TITLE
refactor: Centralize query condition building in `QueryConditionBuilder`.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -619,10 +619,6 @@ class NestedSetsBehavior extends Behavior
      */
     public function insertAfter(ActiveRecord $node, bool $runValidation = true, array|null $attributes = null): bool
     {
-        if ($node->getIsNewRecord() === true) {
-            throw new Exception('Can not move a node when the target node is new record.');
-        }
-
         $this->operation = self::OPERATION_INSERT_AFTER;
         $this->node = $node;
 

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -502,7 +502,7 @@ class NestedSetsBehavior extends Behavior
             $this->getTreeValue($this->getOwner()),
             $depth !== null ? $this->depthAttribute : null,
             $depth !== null ? $this->getDepthValue() : null,
-            $depth
+            $depth,
         );
 
         return $this->getOwner()::find()->andWhere($condition)->addOrderBy([$this->leftAttribute => SORT_ASC]);
@@ -929,7 +929,7 @@ class NestedSetsBehavior extends Behavior
             $this->getTreeValue($this->getOwner()),
             $depth !== null ? $this->depthAttribute : null,
             $depth !== null ? $this->getDepthValue() : null,
-            $depth
+            $depth,
         );
 
         return $this->getOwner()::find()->andWhere($condition)->addOrderBy([$this->leftAttribute => SORT_ASC]);
@@ -1146,7 +1146,7 @@ class NestedSetsBehavior extends Behavior
                 $this->rightAttribute,
                 $ownerRightValue,
                 $this->treeAttribute,
-                $currentOwnerTreeValue
+                $currentOwnerTreeValue,
             );
 
             $this->getOwner()::updateAll(
@@ -1165,7 +1165,7 @@ class NestedSetsBehavior extends Behavior
                     $attribute,
                     $ownerRightValue,
                     $this->treeAttribute,
-                    $currentOwnerTreeValue
+                    $currentOwnerTreeValue,
                 );
 
                 $this->getOwner()::updateAll(
@@ -1186,7 +1186,7 @@ class NestedSetsBehavior extends Behavior
                     $attribute,
                     $context->targetPositionValue,
                     $this->treeAttribute,
-                    $targetNodeTreeValue
+                    $targetNodeTreeValue,
                 );
 
                 $this->getOwner()::updateAll(
@@ -1438,7 +1438,7 @@ class NestedSetsBehavior extends Behavior
             $this->rightAttribute,
             $rightValue,
             $this->treeAttribute,
-            $currentOwnerTreeValue
+            $currentOwnerTreeValue,
         );
         $this->getOwner()::updateAll(
             [

--- a/src/QueryConditionBuilder.php
+++ b/src/QueryConditionBuilder.php
@@ -84,7 +84,7 @@ final class QueryConditionBuilder
             $condition[] = ['<=', $depthAttribute, $parentDepth + $maxRelativeDepth];
         }
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             $condition[] = [$treeAttribute => $treeValue];
         }
 
@@ -176,7 +176,7 @@ final class QueryConditionBuilder
             ];
         }
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             if (isset($condition[0]) && $condition[0] === 'and') {
                 $condition[] = [$treeAttribute => $treeValue];
             }
@@ -214,7 +214,7 @@ final class QueryConditionBuilder
     ): array {
         $condition = [$leftAttribute => $rightValue + 1];
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             $condition = ['and', $condition, [$treeAttribute => $treeValue]];
         }
 
@@ -276,7 +276,7 @@ final class QueryConditionBuilder
             $condition[] = ['>=', $depthAttribute, $childDepth - $maxRelativeDepth];
         }
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             $condition[] = [$treeAttribute => $treeValue];
         }
 
@@ -312,7 +312,7 @@ final class QueryConditionBuilder
     ): array {
         $condition = [$rightAttribute => $leftValue - 1];
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             $condition = ['and', $condition, [$treeAttribute => $treeValue]];
         }
 
@@ -362,7 +362,7 @@ final class QueryConditionBuilder
             ['<=', $rightAttribute, $rightValue],
         ];
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             $condition[] = [$treeAttribute => $treeValue];
         }
 
@@ -398,7 +398,7 @@ final class QueryConditionBuilder
     ): array {
         $condition = ['>=', $attribute, $value];
 
-        if ($treeAttribute !== false && $treeValue !== null) {
+        if ($treeAttribute !== false) {
             $condition = ['and', $condition, [$treeAttribute => $treeValue]];
         }
 

--- a/src/QueryConditionBuilder.php
+++ b/src/QueryConditionBuilder.php
@@ -44,7 +44,7 @@ final class QueryConditionBuilder
      * @param int $leftValue Parent node left value.
      * @param string $rightAttribute Name of the right boundary attribute.
      * @param int $rightValue Parent node right value.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      * @param string|null $depthAttribute Name of the depth attribute, or `null` if depth filtering is not needed.
      * @param int|null $parentDepth Parent node depth value, required if $maxRelativeDepth is provided.
@@ -134,7 +134,7 @@ final class QueryConditionBuilder
      *
      * @param string $leftAttribute Name of the left boundary attribute.
      * @param string $rightAttribute Name of the right boundary attribute.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      * @param int|null $parentLeftValue Optional parent left value to restrict search to a subtree.
      * @param int|null $parentRightValue Optional parent right value to restrict search to a subtree.
@@ -193,7 +193,7 @@ final class QueryConditionBuilder
      *
      * @param string $leftAttribute Name of the left boundary attribute.
      * @param int $rightValue Reference node right value.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      *
      * @return array Condition array for finding the next sibling.
@@ -236,7 +236,7 @@ final class QueryConditionBuilder
      * @param int $leftValue Child node left value.
      * @param string $rightAttribute Name of the right boundary attribute.
      * @param int $rightValue Child node right value.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      * @param string|null $depthAttribute Name of the depth attribute, or `null` if depth filtering is not needed.
      * @param int|null $childDepth Child node depth value, required if $maxRelativeDepth is provided.
@@ -291,7 +291,7 @@ final class QueryConditionBuilder
      *
      * @param string $rightAttribute Name of the right boundary attribute.
      * @param int $leftValue Reference node left value.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      *
      * @return array Condition array for finding the previous sibling.
@@ -335,7 +335,7 @@ final class QueryConditionBuilder
      * @param int $leftValue Left boundary value.
      * @param string $rightAttribute Name of the right boundary attribute.
      * @param int $rightValue Right boundary value.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      *
      * @return array Condition array for finding nodes within the specified range.
@@ -377,7 +377,7 @@ final class QueryConditionBuilder
      *
      * @param string $attribute Name of the attribute to check (left or right).
      * @param int $value Minimum value for the attribute.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
      *
      * @return array Condition array for shifting operations.
@@ -414,7 +414,7 @@ final class QueryConditionBuilder
      * @param int $leftValue Left boundary value of the subtree.
      * @param string $rightAttribute Name of the right boundary attribute.
      * @param int $rightValue Right boundary value of the subtree.
-     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param false|string $treeAttribute Name of tree attribute or `false` if disabled.
      * @param mixed $currentTreeValue Current tree value of the subtree.
      *
      * @return array Condition array for subtree movement.
@@ -424,7 +424,6 @@ final class QueryConditionBuilder
      * $condition = QueryConditionBuilder::createSubtreeMoveCondition('lft', 5, 'rgt', 10, 'tree', 1);
      * MyModel::updateAll(['tree' => 2], $condition);
      * ```
-     *
      */
     public static function createSubtreeMoveCondition(
         string $leftAttribute,

--- a/src/QueryConditionBuilder.php
+++ b/src/QueryConditionBuilder.php
@@ -424,6 +424,8 @@ final class QueryConditionBuilder
      * $condition = QueryConditionBuilder::createSubtreeMoveCondition('lft', 5, 'rgt', 10, 'tree', 1);
      * MyModel::updateAll(['tree' => 2], $condition);
      * ```
+     *
+     * @phpstan-return array<int|string, mixed>
      */
     public static function createSubtreeMoveCondition(
         string $leftAttribute,

--- a/src/QueryConditionBuilder.php
+++ b/src/QueryConditionBuilder.php
@@ -161,25 +161,15 @@ final class QueryConditionBuilder
         int|null $parentLeftValue = null,
         int|null $parentRightValue = null,
     ): array {
-        $leafCondition = [
-            $rightAttribute => new Expression("{{{$leftAttribute}}} + 1"),
+        $condition = [
+            'and',
+            [$rightAttribute => new Expression("{{{$leftAttribute}}} + 1")],
+            ['>', $leftAttribute, $parentLeftValue],
+            ['<', $rightAttribute, $parentRightValue],
         ];
 
-        $condition = $leafCondition;
-
-        if ($parentLeftValue !== null && $parentRightValue !== null) {
-            $condition = [
-                'and',
-                $leafCondition,
-                ['>', $leftAttribute, $parentLeftValue],
-                ['<', $rightAttribute, $parentRightValue],
-            ];
-        }
-
         if ($treeAttribute !== false) {
-            if (isset($condition[0]) && $condition[0] === 'and') {
-                $condition[] = [$treeAttribute => $treeValue];
-            }
+            $condition[] = [$treeAttribute => $treeValue];
         }
 
         return $condition;

--- a/src/QueryConditionBuilder.php
+++ b/src/QueryConditionBuilder.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\nestedsets;
+
+use yii\db\Expression;
+
+/**
+ * Utility class for building query conditions for nested sets operations.
+ *
+ * Provides static methods to create standardized condition arrays for common nested sets queries such as finding
+ * descendants, ancestors, siblings, or filtering by tree.
+ *
+ * These methods ensure consistent condition structure and reduce code duplication across the nested sets behavior.
+ *
+ * This class focuses on creating query conditions without executing them, making it useful for both the behavior
+ * implementation and external queries that need to work with nested sets.
+ *
+ * Key features:
+ * - Creates standardized condition arrays for nested sets queries.
+ * - Enables consistent tree filtering across multiple operations.
+ * - Handles range conditions for subtree operations.
+ * - Supports specific node relationship queries (children, parents, siblings).
+ * - Provides leaf node and level-based filtering conditions.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class QueryConditionBuilder
+{
+    /**
+     * Creates a condition array for finding children of a node with specific left and right values.
+     *
+     * This method builds a condition that identifies all nodes that are direct descendants of a node with the specified
+     * boundaries.
+     *
+     * It requires the left attribute to be greater than the parent's left value and the right attribute to be less than
+     * the parent's right value.
+     *
+     * Optionally limits the depth of children if the depth parameter is provided.
+     *
+     * @param string $leftAttribute Name of the left boundary attribute.
+     * @param int $leftValue Parent node left value.
+     * @param string $rightAttribute Name of the right boundary attribute.
+     * @param int $rightValue Parent node right value.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     * @param string|null $depthAttribute Name of the depth attribute, or `null` if depth filtering is not needed.
+     * @param int|null $parentDepth Parent node depth value, required if $maxRelativeDepth is provided.
+     * @param int|null $maxRelativeDepth Maximum relative depth from parent, or `null` for all descendants.
+     *
+     * @return array Condition array for finding children of the specified node.
+     *
+     * Usage example:
+     * ```php
+     * // Find all children up to 2 levels deep
+     * $condition = QueryConditionBuilder::createChildrenCondition(
+     *     'lft', $node->lft, 'rgt', $node->rgt, 'tree', $node->tree, 'depth', $node->depth, 2,
+     * );
+     * $children = MyModel::find()->andWhere($condition)->all();
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createChildrenCondition(
+        string $leftAttribute,
+        int $leftValue,
+        string $rightAttribute,
+        int $rightValue,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+        string|null $depthAttribute = null,
+        int|null $parentDepth = null,
+        int|null $maxRelativeDepth = null,
+    ): array {
+        $condition = [
+            'and',
+            ['>', $leftAttribute, $leftValue],
+            ['<', $rightAttribute, $rightValue],
+        ];
+
+        if ($depthAttribute !== null && $parentDepth !== null && $maxRelativeDepth !== null) {
+            $condition[] = ['<=', $depthAttribute, $parentDepth + $maxRelativeDepth];
+        }
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            $condition[] = [$treeAttribute => $treeValue];
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for cross-tree movement operations.
+     *
+     * This method builds a condition for updating nodes when moving subtrees between different trees.
+     *
+     * @param string $attribute Name of the attribute to check (left or right).
+     * @param int $value Minimum value for the attribute.
+     * @param string $treeAttribute Name of tree attribute.
+     * @param mixed $treeValue Tree value to filter by.
+     *
+     * @return array Condition array for cross-tree operations.
+     *
+     * Usage example:
+     * ```php
+     * $condition = QueryConditionBuilder::createCrossTreeMoveCondition('lft', 5, 'tree', 2);
+     * MyModel::updateAll(['lft' => new Expression('lft + 10')], $condition);
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createCrossTreeMoveCondition(
+        string $attribute,
+        int $value,
+        string $treeAttribute,
+        mixed $treeValue,
+    ): array {
+        return [
+            'and',
+            ['>=', $attribute, $value],
+            [$treeAttribute => $treeValue],
+        ];
+    }
+
+    /**
+     * Creates a condition array for finding leaf nodes (nodes without children).
+     *
+     * This method builds a condition that identifies all nodes where the right attribute is exactly one greater than
+     * the left attribute, indicating that the node has no children.
+     *
+     * Optionally restricts the search to descendants of a specific node if parent boundaries are provided.
+     *
+     * @param string $leftAttribute Name of the left boundary attribute.
+     * @param string $rightAttribute Name of the right boundary attribute.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     * @param int|null $parentLeftValue Optional parent left value to restrict search to a subtree.
+     * @param int|null $parentRightValue Optional parent right value to restrict search to a subtree.
+     *
+     * @return array Condition array for finding leaf nodes.
+     *
+     * Usage example:
+     * ```php
+     * // Find all leaf nodes in the tree
+     * $condition = QueryConditionBuilder::createLeavesCondition('lft', 'rgt', 'tree', 1);
+     * $leaves = MyModel::find()->andWhere($condition)->all();
+     *
+     * // Find leaf nodes only within a specific subtree
+     * $condition = QueryConditionBuilder::createLeavesCondition('lft', 'rgt', 'tree', 1, $node->lft, $node->rgt);
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createLeavesCondition(
+        string $leftAttribute,
+        string $rightAttribute,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+        int|null $parentLeftValue = null,
+        int|null $parentRightValue = null,
+    ): array {
+        $leafCondition = [
+            $rightAttribute => new Expression("{{{$leftAttribute}}} + 1"),
+        ];
+
+        $condition = $leafCondition;
+
+        if ($parentLeftValue !== null && $parentRightValue !== null) {
+            $condition = [
+                'and',
+                $leafCondition,
+                ['>', $leftAttribute, $parentLeftValue],
+                ['<', $rightAttribute, $parentRightValue],
+            ];
+        }
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            if (isset($condition[0]) && $condition[0] === 'and') {
+                $condition[] = [$treeAttribute => $treeValue];
+            }
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for finding the next sibling of a node.
+     *
+     * This method builds a condition that identifies the node whose left attribute is exactly one greater than the
+     * right attribute of the reference node.
+     *
+     * @param string $leftAttribute Name of the left boundary attribute.
+     * @param int $rightValue Reference node right value.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     *
+     * @return array Condition array for finding the next sibling.
+     *
+     * Usage example:
+     * ```php
+     * $condition = QueryConditionBuilder::createNextSiblingCondition('lft', $node->rgt, 'tree', $node->tree);
+     * $nextSibling = MyModel::find()->andWhere($condition)->one();
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createNextSiblingCondition(
+        string $leftAttribute,
+        int $rightValue,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+    ): array {
+        $condition = [$leftAttribute => $rightValue + 1];
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            $condition = ['and', $condition, [$treeAttribute => $treeValue]];
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for finding parent nodes of a node with specific left and right values.
+     *
+     * This method builds a condition that identifies all nodes that are ancestors of a node with the specified
+     * boundaries.
+     *
+     * It requires the left attribute to be less than the child's left value and the right attribute to be greater than
+     * the child's right value.
+     *
+     * Optionally limits the depth of parents if the depth parameter is provided.
+     *
+     * @param string $leftAttribute Name of the left boundary attribute.
+     * @param int $leftValue Child node left value.
+     * @param string $rightAttribute Name of the right boundary attribute.
+     * @param int $rightValue Child node right value.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     * @param string|null $depthAttribute Name of the depth attribute, or `null` if depth filtering is not needed.
+     * @param int|null $childDepth Child node depth value, required if $maxRelativeDepth is provided.
+     * @param int|null $maxRelativeDepth Maximum relative depth from child, or `null` for all ancestors.
+     *
+     * @return array Condition array for finding parents of the specified node.
+     *
+     * Usage example:
+     * ```php
+     * // Find direct parent and grandparent only
+     * $condition = QueryConditionBuilder::createParentsCondition(
+     *     'lft', $node->lft, 'rgt', $node->rgt, 'tree', $node->tree, 'depth', $node->depth, 2,
+     * );
+     * $parents = MyModel::find()->andWhere($condition)->all();
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createParentsCondition(
+        string $leftAttribute,
+        int $leftValue,
+        string $rightAttribute,
+        int $rightValue,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+        string|null $depthAttribute = null,
+        int|null $childDepth = null,
+        int|null $maxRelativeDepth = null,
+    ): array {
+        $condition = [
+            'and',
+            ['<', $leftAttribute, $leftValue],
+            ['>', $rightAttribute, $rightValue],
+        ];
+
+        if ($depthAttribute !== null && $childDepth !== null && $maxRelativeDepth !== null) {
+            $condition[] = ['>=', $depthAttribute, $childDepth - $maxRelativeDepth];
+        }
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            $condition[] = [$treeAttribute => $treeValue];
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for finding the previous sibling of a node.
+     *
+     * This method builds a condition that identifies the node whose right attribute is exactly one less than the left
+     * attribute of the reference node.
+     *
+     * @param string $rightAttribute Name of the right boundary attribute.
+     * @param int $leftValue Reference node left value.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     *
+     * @return array Condition array for finding the previous sibling.
+     *
+     * Usage example:
+     * ```php
+     * $condition = QueryConditionBuilder::createPrevSiblingCondition('rgt', $node->lft, 'tree', $node->tree);
+     * $prevSibling = MyModel::find()->andWhere($condition)->one();
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createPrevSiblingCondition(
+        string $rightAttribute,
+        int $leftValue,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+    ): array {
+        $condition = [$rightAttribute => $leftValue - 1];
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            $condition = ['and', $condition, [$treeAttribute => $treeValue]];
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for finding nodes within a range of left and right values.
+     *
+     * This is the core condition builder for nested sets operations, used to identify nodes within a specific subtree
+     * boundary.
+     *
+     * It creates an 'and' condition that requires both the left attribute to be greater than or equal to the left
+     * value, and the right attribute to be less than or equal to the right value.
+     *
+     * This condition is essential for operations like finding descendants, deleting subtrees, or moving nodes within
+     * the nested set structure.
+     *
+     * @param string $leftAttribute Name of the left boundary attribute.
+     * @param int $leftValue Left boundary value.
+     * @param string $rightAttribute Name of the right boundary attribute.
+     * @param int $rightValue Right boundary value.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     *
+     * @return array Condition array for finding nodes within the specified range.
+     *
+     * Usage example:
+     * ```php
+     * $condition = QueryConditionBuilder::createRangeCondition('lft', 5, 'rgt', 10, 'tree', 1);
+     * $descendants = MyModel::find()->andWhere($condition)->all();
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createRangeCondition(
+        string $leftAttribute,
+        int $leftValue,
+        string $rightAttribute,
+        int $rightValue,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+    ): array {
+        $condition = [
+            'and',
+            ['>=', $leftAttribute, $leftValue],
+            ['<=', $rightAttribute, $rightValue],
+        ];
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            $condition[] = [$treeAttribute => $treeValue];
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for shifting left/right attributes.
+     *
+     * This method builds a condition for nodes that need their left or right attributes updated during tree
+     * restructuring operations.
+     *
+     * @param string $attribute Name of the attribute to check (left or right).
+     * @param int $value Minimum value for the attribute.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $treeValue Tree value to filter by (ignored if treeAttribute is `false`).
+     *
+     * @return array Condition array for shifting operations.
+     *
+     * Usage example:
+     * ```php
+     * $condition = QueryConditionBuilder::createShiftCondition('lft', 10, 'tree', 1);
+     * MyModel::updateAll(['lft' => new Expression('lft + 2')], $condition);
+     * ```
+     *
+     * @phpstan-return array<int|string, mixed>
+     */
+    public static function createShiftCondition(
+        string $attribute,
+        int $value,
+        string|false $treeAttribute = false,
+        mixed $treeValue = null,
+    ): array {
+        $condition = ['>=', $attribute, $value];
+
+        if ($treeAttribute !== false && $treeValue !== null) {
+            $condition = ['and', $condition, [$treeAttribute => $treeValue]];
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Creates a condition array for moving a subtree to a different tree.
+     *
+     * This method builds a condition for identifying nodes in a subtree that need to be moved from one tree to another.
+     *
+     * @param string $leftAttribute Name of the left boundary attribute.
+     * @param int $leftValue Left boundary value of the subtree.
+     * @param string $rightAttribute Name of the right boundary attribute.
+     * @param int $rightValue Right boundary value of the subtree.
+     * @param string|false $treeAttribute Name of tree attribute or `false` if disabled.
+     * @param mixed $currentTreeValue Current tree value of the subtree.
+     *
+     * @return array Condition array for subtree movement.
+     *
+     * Usage example:
+     * ```php
+     * $condition = QueryConditionBuilder::createSubtreeMoveCondition('lft', 5, 'rgt', 10, 'tree', 1);
+     * MyModel::updateAll(['tree' => 2], $condition);
+     * ```
+     *
+     */
+    public static function createSubtreeMoveCondition(
+        string $leftAttribute,
+        int $leftValue,
+        string $rightAttribute,
+        int $rightValue,
+        string|false $treeAttribute,
+        mixed $currentTreeValue,
+    ): array {
+        $condition = [
+            'and',
+            ['>=', $leftAttribute, $leftValue],
+            ['<=', $rightAttribute, $rightValue],
+        ];
+
+        if ($treeAttribute !== false) {
+            $condition[] = [$treeAttribute => $currentTreeValue];
+        }
+
+        return $condition;
+    }
+}

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -229,18 +229,6 @@ final class NestedSetsBehaviorTest extends TestCase
         );
     }
 
-    public function testThrowExceptionWhenInsertAfterNewNodeTargetIsNewRecord(): void
-    {
-        $this->generateFixtureTree();
-
-        $node = new Tree(['name' => 'New node']);
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Can not create a node when the target node is new record.');
-
-        $node->insertAfter(new Tree());
-    }
-
     public function testThrowExceptionWhenInsertAfterNewNodeTargetIsRoot(): void
     {
         $this->generateFixtureTree();
@@ -2021,20 +2009,6 @@ final class NestedSetsBehaviorTest extends TestCase
             ExtendableNestedSetsBehavior::class,
             $extendableBehavior,
             "'ExtendableMultipleTree' should use 'ExtendableNestedSetsBehavior'.",
-        );
-
-        $condition = ['name' => 'test'];
-
-        $extendableBehavior->exposedApplyTreeAttributeCondition($condition);
-
-        self::assertTrue(
-            $extendableBehavior->wasMethodCalled('applyTreeAttributeCondition'),
-            "'applyTreeAttributeCondition' method should remain protected to allow subclass access.",
-        );
-        self::assertEquals(
-            ['and', ['name' => 'test'], ['tree' => 1]],
-            $condition,
-            "'Tree' attribute condition should be applied correctly when 'treeAttribute' is enabled.",
         );
     }
 

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -19,16 +19,6 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
      */
     public array $calledMethods = [];
 
-    /**
-     * @phpstan-param array<int|string, mixed> $condition
-     */
-    public function exposedApplyTreeAttributeCondition(array &$condition): void
-    {
-        $this->calledMethods['applyTreeAttributeCondition'] = true;
-
-        $this->applyTreeAttributeCondition($condition);
-    }
-
     public function exposedBeforeInsertNode(int $value, int $depth): void
     {
         $this->calledMethods['beforeInsertNode'] = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility for building standardized query conditions for nested set tree operations, improving consistency and reusability.

* **Improvements**
  * Enhanced performance by caching node attributes for left, right, and depth values.
  * Improved exception messages for clarity.
  * Strengthened validation when inserting after a node.

* **Refactor**
  * Centralized and streamlined query condition construction for tree-related operations.
  * Removed redundant internal methods related to tree attribute condition application.

* **Tests**
  * Removed tests related to previously used internal methods and exception handling for deprecated behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->