### PR TITLE
feat: Add cache invalidation method and tests for `NestedSetsBehavior`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "ext-simplexml": "*",
         "infection/infection": "^0.27|^0.29",
         "maglnet/composer-require-checker": "^4.1",
+        "php-forge/support": "^0.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",
         "phpunit/phpunit": "^10.2",

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -193,9 +193,7 @@ class NestedSetsBehavior extends Behavior
         }
 
         $this->shiftLeftRightAttribute($this->getRightValue(), $deltaValue);
-
-        $this->operation = null;
-        $this->node = null;
+        $this->invalidateCache();
     }
 
     /**
@@ -235,8 +233,7 @@ class NestedSetsBehavior extends Behavior
             );
         }
 
-        $this->operation = null;
-        $this->node = null;
+        $this->invalidateCache();
     }
 
     /**
@@ -268,17 +265,44 @@ class NestedSetsBehavior extends Behavior
 
         if ($this->operation === self::OPERATION_MAKE_ROOT) {
             $this->moveNodeAsRoot($currentOwnerTreeValue);
+            $this->invalidateCache();
 
             return;
         }
 
         if ($this->node === null) {
+            $this->invalidateCache();
+
             return;
         }
 
         $context = $this->createMoveContext($this->node, $this->operation);
-
         $this->moveNode($context);
+        $this->invalidateCache();
+    }
+
+    /**
+     * Invalidates cached attribute values and resets internal state.
+     *
+     * Clears the cached depth, left, and right attribute values, forcing them to be re-fetched from the owner model
+     * on next access.
+     *
+     * This method should be called after operations that modify the owner model's attributes to ensure that cached
+     * values remain consistent with the actual model state.
+     *
+     * Usage example:
+     * ```php
+     * // After modifying the model's attributes externally
+     * $behavior->invalidateCache();
+     * ```
+     */
+    public function invalidateCache(): void
+    {
+        $this->depthValue = null;
+        $this->leftValue = null;
+        $this->node = null;
+        $this->operation = null;
+        $this->rightValue = null;
     }
 
     /**

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -104,6 +104,11 @@ class NestedSetsBehavior extends Behavior
     public string $depthAttribute = 'depth';
 
     /**
+     * Stores the depth value for the current operation.
+     */
+    protected int|null $depthValue = null;
+
+    /**
      * Name of the attribute that stores the left boundary value of the node in the nested set tree.
      *
      * @phpstan-var 'lft' attribute name.
@@ -111,11 +116,21 @@ class NestedSetsBehavior extends Behavior
     public string $leftAttribute = 'lft';
 
     /**
+     * Stores the left value for the current operation.
+     */
+    protected int|null $leftValue = null;
+
+    /**
      * Name of the attribute that stores the right boundary value of the node in the nested set tree.
      *
      * @phpstan-var 'rgt' attribute name.
      */
     public string $rightAttribute = 'rgt';
+
+    /**
+     * Stores the right value for the current operation.
+     */
+    protected int|null $rightValue = null;
 
     /**
      * Name of the attribute that stores the tree identifier for supporting multiple trees.
@@ -129,21 +144,6 @@ class NestedSetsBehavior extends Behavior
      * allowing the behavior to perform database operations such as updates and queries.
      */
     private Connection|null $db = null;
-
-    /**
-     * Stores the depth value for the current operation.
-     */
-    private int|null $depthValue = null;
-
-    /**
-     * Stores the left value for the current operation.
-     */
-    private int|null $leftValue = null;
-
-    /**
-     * Stores the right value for the current operation.
-     */
-    private int|null $rightValue = null;
 
     /**
      * Handles post-deletion updates for the nested set structure.

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -7,7 +7,7 @@ namespace yii2\extensions\nestedsets\tests;
 use LogicException;
 use PHPForge\Support\Assert;
 use Throwable;
-use yii\base\NotSupportedException;
+use yii\base\{Behavior, NotSupportedException};
 use yii\db\{ActiveRecord, Exception, StaleObjectException};
 use yii\helpers\ArrayHelper;
 use yii2\extensions\nestedsets\NestedSetsBehavior;
@@ -2321,26 +2321,8 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $child->makeRoot();
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'node'),
-            "Node cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'operation'),
-            "Operation cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be 'null' after manual invalidation.",
-        );
+        $this->verifyCacheInvalidation($behavior);
+
         self::assertEquals(
             0,
             Assert::invokeMethod($behavior, 'getDepthValue'),
@@ -2381,37 +2363,11 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $child2->appendTo($root);
 
-        Assert::invokeMethod($behavior, 'getDepthValue');
-        Assert::invokeMethod($behavior, 'getLeftValue');
-        Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            'Depth value cache should be populated before movement.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            'Left value cache should be populated before movement.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            'Right value cache should be populated before movement.',
-        );
+        $this->populateAndVerifyCache($behavior);
 
         $child2->appendTo($child1);
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be invalidated after 'appendTo()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be invalidated after 'appendTo()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be invalidated after 'appendTo()'.",
-        );
+        $this->verifyCacheInvalidation($behavior);
     }
 
     public function testCacheInvalidationAfterDeleteWithChildren(): void
@@ -2436,37 +2392,11 @@ final class NestedSetsBehaviorTest extends TestCase
             'Behavior should be attached to the child node.',
         );
 
-        Assert::invokeMethod($behavior, 'getDepthValue');
-        Assert::invokeMethod($behavior, 'getLeftValue');
-        Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            'Depth value cache should be populated before deletion.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            'Left value cache should be populated before deletion.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            'Right value cache should be populated before deletion.',
-        );
+        $this->populateAndVerifyCache($behavior);
 
         $child->deleteWithChildren();
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be invalidated after 'deleteWithChildren()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be invalidated after 'deleteWithChildren()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be invalidated after 'deleteWithChildren()'.",
-        );
+        $this->verifyCacheInvalidation($behavior);
     }
 
     public function testManualCacheInvalidation(): void
@@ -2484,45 +2414,12 @@ final class NestedSetsBehaviorTest extends TestCase
             'Behavior should be attached to the root node.',
         );
 
-        Assert::invokeMethod($behavior, 'getDepthValue');
-        Assert::invokeMethod($behavior, 'getLeftValue');
-        Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            'Depth value cache should be populated.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            'Left value cache should be populated.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            'Right value cache should be populated.',
-        );
+        $this->populateAndVerifyCache($behavior);
 
         $root->invalidateCache();
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'node'),
-            "Node cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'operation'),
-            "Operation cache should be 'null' after manual invalidation.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be 'null' after manual invalidation.",
-        );
+        $this->verifyCacheInvalidation($behavior);
+
         self::assertEquals(
             0,
             Assert::invokeMethod($behavior, 'getDepthValue'),
@@ -2555,37 +2452,12 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $node->makeRoot();
 
-        Assert::invokeMethod($behavior, 'getDepthValue');
-        Assert::invokeMethod($behavior, 'getLeftValue');
-        Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            'Depth value cache should be populated after access.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            'Left value cache should be populated after access.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            'Right value cache should be populated after access.',
-        );
+        $this->populateAndVerifyCache($behavior);
 
         $node->invalidateCache();
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be invalidated after 'invalidateCache()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be invalidated after 'invalidateCache()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be invalidated after 'invalidateCache()'.",
-        );
+        $this->verifyCacheInvalidation($behavior);
+
         self::assertEquals(
             0,
             Assert::invokeMethod($behavior, 'getDepthValue'),
@@ -2635,37 +2507,12 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $node->makeRoot();
 
-        Assert::invokeMethod($behavior, 'getDepthValue');
-        Assert::invokeMethod($behavior, 'getLeftValue');
-        Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            'Depth value cache should be populated after access.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            'Left value cache should be populated after access.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            'Right value cache should be populated after access.',
-        );
+        $this->populateAndVerifyCache($behavior);
 
         $node->invalidateCache();
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be invalidated after 'invalidateCache()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be invalidated after 'invalidateCache()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be invalidated after 'invalidateCache()'.",
-        );
+        $this->verifyCacheInvalidation($behavior);
+
         self::assertEquals(
             0,
             Assert::invokeMethod($behavior, 'getDepthValue'),
@@ -2752,37 +2599,12 @@ final class NestedSetsBehaviorTest extends TestCase
             "Child should start with 'rgt=3'.",
         );
 
-        Assert::invokeMethod($behavior, 'getDepthValue');
-        Assert::invokeMethod($behavior, 'getLeftValue');
-        Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            'Depth value cache should be populated.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            'Left value cache should be populated.',
-        );
-        self::assertNotNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            'Right value cache should be populated.',
-        );
+        $this->populateAndVerifyCache($behavior);
 
         $child->makeRoot();
 
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'depthValue'),
-            "Depth value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'leftValue'),
-            "Left value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
-        );
-        self::assertNull(
-            Assert::inaccessibleProperty($behavior, 'rightValue'),
-            "Right value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
-        );
+        $this->verifyCacheInvalidation($behavior);
+
         self::assertEquals(
             0,
             $child->getAttribute('depth'),
@@ -2812,6 +2634,56 @@ final class NestedSetsBehaviorTest extends TestCase
             2,
             Assert::invokeMethod($behavior, 'getRightValue'),
             "New cached right should be '2'.",
+        );
+    }
+
+    /**
+     * @phpstan-param Behavior<ActiveRecord> $behavior
+     */
+    private function populateAndVerifyCache(Behavior $behavior): void
+    {
+        Assert::invokeMethod($behavior, 'getDepthValue');
+        Assert::invokeMethod($behavior, 'getLeftValue');
+        Assert::invokeMethod($behavior, 'getRightValue');
+
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated.',
+        );
+    }
+
+    /**
+     * @phpstan-param Behavior<ActiveRecord> $behavior
+     */
+    private function verifyCacheInvalidation(Behavior $behavior): void
+    {
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'node'),
+            "Node cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'operation'),
+            "Operation cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
         );
     }
 }

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2298,41 +2298,64 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $behavior = $child->getBehavior('nestedSetsBehavior');
 
-        self::assertNotNull($behavior, 'Behavior should be attached to the child node.');
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the child node.',
+        );
 
-        $originalDepth = $child->getAttribute('depth');
-        $originalLeft = $child->getAttribute('lft');
-        $originalRight = $child->getAttribute('rgt');
-
-        $cachedDepth = Assert::invokeMethod($behavior, 'getDepthValue');
-        $cachedLeft = Assert::invokeMethod($behavior, 'getLeftValue');
-        $cachedRight = Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertEquals($originalDepth, $cachedDepth, 'Initial cached depth value should match attribute.');
-        self::assertEquals($originalLeft, $cachedLeft, 'Initial cached left value should match attribute.');
-        self::assertEquals($originalRight, $cachedRight, 'Initial cached right value should match attribute.');
+        self::assertEquals(
+            $child->getAttribute('depth'),
+            Assert::invokeMethod($behavior, 'getDepthValue'),
+            'Initial cached depth value should match attribute.',
+        );
+        self::assertEquals(
+            $child->getAttribute('lft'),
+            Assert::invokeMethod($behavior, 'getLeftValue'),
+            'Initial cached left value should match attribute.',
+        );
+        self::assertEquals(
+            $child->getAttribute('rgt'),
+            Assert::invokeMethod($behavior, 'getRightValue'),
+            'Initial cached right value should match attribute.',
+        );
 
         $child->makeRoot();
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $nodeValueProperty = Assert::inaccessibleProperty($behavior, 'node');
-        $operationProperty = Assert::inaccessibleProperty($behavior, 'operation');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
-
-        self::assertNull($depthValueProperty, 'Depth value cache should be null after manual invalidation.');
-        self::assertNull($leftValueProperty, 'Left value cache should be null after manual invalidation.');
-        self::assertNull($nodeValueProperty, 'Node cache should be null after manual invalidation.');
-        self::assertNull($operationProperty, 'Operation cache should be null after manual invalidation.');
-        self::assertNull($rightValueProperty, 'Right value cache should be null after manual invalidation.');
-
-        $newDepth = Assert::invokeMethod($behavior, 'getDepthValue');
-        $newLeft = Assert::invokeMethod($behavior, 'getLeftValue');
-        $newRight = Assert::invokeMethod($behavior, 'getRightValue');
-
-        self::assertEquals(0, $newDepth, 'New cached depth value should be 0 for root.');
-        self::assertEquals(1, $newLeft, 'New cached left value should be 1 for root.');
-        self::assertEquals(2, $newRight, 'New cached right value should be 2 for root.');
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'node'),
+            "Node cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'operation'),
+            "Operation cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be 'null' after manual invalidation.",
+        );
+        self::assertEquals(
+            0,
+            Assert::invokeMethod($behavior, 'getDepthValue'),
+            "New cached depth value should be '0' for root.",
+        );
+        self::assertEquals(
+            1,
+            Assert::invokeMethod($behavior, 'getLeftValue'),
+            "New cached left value should be '1' for root.",
+        );
+        self::assertEquals(
+            2,
+            Assert::invokeMethod($behavior, 'getRightValue'),
+            "New cached right value should be '2' for root.",
+        );
     }
 
     public function testCacheInvalidationAfterAppendTo(): void
@@ -2351,7 +2374,10 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $behavior = $child2->getBehavior('nestedSetsBehavior');
 
-        self::assertNotNull($behavior, 'Behavior should be attached to the child node.');
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the child node.',
+        );
 
         $child2->appendTo($root);
 
@@ -2359,23 +2385,33 @@ final class NestedSetsBehaviorTest extends TestCase
         Assert::invokeMethod($behavior, 'getLeftValue');
         Assert::invokeMethod($behavior, 'getRightValue');
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
-
-        self::assertNotNull($depthValueProperty, 'Depth value cache should be populated before movement.');
-        self::assertNotNull($leftValueProperty, 'Left value cache should be populated before movement.');
-        self::assertNotNull($rightValueProperty, 'Right value cache should be populated before movement.');
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated before movement.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated before movement.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated before movement.',
+        );
 
         $child2->appendTo($child1);
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
-
-        self::assertNull($depthValueProperty, 'Depth value cache should be invalidated after appendTo.');
-        self::assertNull($leftValueProperty, 'Left value cache should be invalidated after appendTo.');
-        self::assertNull($rightValueProperty, 'Right value cache should be invalidated after appendTo.');
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be invalidated after 'appendTo()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be invalidated after 'appendTo()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be invalidated after 'appendTo()'.",
+        );
     }
 
     public function testCacheInvalidationAfterDeleteWithChildren(): void
@@ -2395,29 +2431,42 @@ final class NestedSetsBehaviorTest extends TestCase
         $grandchild->appendTo($child);
         $behavior = $child->getBehavior('nestedSetsBehavior');
 
-        self::assertNotNull($behavior, 'Behavior should be attached to the child node.');
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the child node.',
+        );
 
         Assert::invokeMethod($behavior, 'getDepthValue');
         Assert::invokeMethod($behavior, 'getLeftValue');
         Assert::invokeMethod($behavior, 'getRightValue');
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
-
-        self::assertNotNull($depthValueProperty, 'Depth value cache should be populated before deletion.');
-        self::assertNotNull($leftValueProperty, 'Left value cache should be populated before deletion.');
-        self::assertNotNull($rightValueProperty, 'Right value cache should be populated before deletion.');
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated before deletion.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated before deletion.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated before deletion.',
+        );
 
         $child->deleteWithChildren();
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
-
-        self::assertNull($depthValueProperty, 'Depth value cache should be invalidated after deleteWithChildren.');
-        self::assertNull($leftValueProperty, 'Left value cache should be invalidated after deleteWithChildren.');
-        self::assertNull($rightValueProperty, 'Right value cache should be invalidated after deleteWithChildren.');
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be invalidated after 'deleteWithChildren()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be invalidated after 'deleteWithChildren()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be invalidated after 'deleteWithChildren()'.",
+        );
     }
 
     public function testManualCacheInvalidation(): void
@@ -2430,40 +2479,339 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $behavior = $root->getBehavior('nestedSetsBehavior');
 
-        self::assertNotNull($behavior, 'Behavior should be attached to the root node.');
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the root node.',
+        );
 
         Assert::invokeMethod($behavior, 'getDepthValue');
         Assert::invokeMethod($behavior, 'getLeftValue');
         Assert::invokeMethod($behavior, 'getRightValue');
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
-
-        self::assertNotNull($depthValueProperty, 'Depth value cache should be populated.');
-        self::assertNotNull($leftValueProperty, 'Left value cache should be populated.');
-        self::assertNotNull($rightValueProperty, 'Right value cache should be populated.');
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated.',
+        );
 
         $root->invalidateCache();
 
-        $depthValueProperty = Assert::inaccessibleProperty($behavior, 'depthValue');
-        $leftValueProperty = Assert::inaccessibleProperty($behavior, 'leftValue');
-        $nodeValueProperty = Assert::inaccessibleProperty($behavior, 'node');
-        $operationProperty = Assert::inaccessibleProperty($behavior, 'operation');
-        $rightValueProperty = Assert::inaccessibleProperty($behavior, 'rightValue');
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'node'),
+            "Node cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'operation'),
+            "Operation cache should be 'null' after manual invalidation.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be 'null' after manual invalidation.",
+        );
+        self::assertEquals(
+            0,
+            Assert::invokeMethod($behavior, 'getDepthValue'),
+            'Depth value should be correctly retrieved after invalidation.',
+        );
+        self::assertEquals(
+            1,
+            Assert::invokeMethod($behavior, 'getLeftValue'),
+            'Left value should be correctly retrieved after invalidation.',
+        );
+        self::assertEquals(
+            2,
+            Assert::invokeMethod($behavior, 'getRightValue'),
+            'Right value should be correctly retrieved after invalidation.',
+        );
+    }
 
-        self::assertNull($depthValueProperty, 'Depth value cache should be null after manual invalidation.');
-        self::assertNull($leftValueProperty, 'Left value cache should be null after manual invalidation.');
-        self::assertNull($nodeValueProperty, 'Node cache should be null after manual invalidation.');
-        self::assertNull($operationProperty, 'Operation cache should be null after manual invalidation.');
-        self::assertNull($rightValueProperty, 'Right value cache should be null after manual invalidation.');
+    public function testCacheInvalidationAfterInsertWithTreeAttribute(): void
+    {
+        $this->createDatabase();
 
-        $newDepth = Assert::invokeMethod($behavior, 'getDepthValue');
-        $newLeft = Assert::invokeMethod($behavior, 'getLeftValue');
-        $newRight = Assert::invokeMethod($behavior, 'getRightValue');
+        $node = new MultipleTree(['name' => 'Root Node']);
 
-        self::assertEquals(0, $newDepth, 'Depth value should be correctly retrieved after invalidation.');
-        self::assertEquals(1, $newLeft, 'Left value should be correctly retrieved after invalidation.');
-        self::assertEquals(2, $newRight, 'Right value should be correctly retrieved after invalidation.');
+        $behavior = $node->getBehavior('nestedSetsBehavior');
+
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the node.',
+        );
+
+        $node->makeRoot();
+
+        Assert::invokeMethod($behavior, 'getDepthValue');
+        Assert::invokeMethod($behavior, 'getLeftValue');
+        Assert::invokeMethod($behavior, 'getRightValue');
+
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated after access.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated after access.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated after access.',
+        );
+
+        $node->invalidateCache();
+
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be invalidated after 'invalidateCache()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be invalidated after 'invalidateCache()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be invalidated after 'invalidateCache()'.",
+        );
+        self::assertEquals(
+            0,
+            Assert::invokeMethod($behavior, 'getDepthValue'),
+            "New cached depth value should be '0' for root.",
+        );
+        self::assertEquals(
+            1,
+            Assert::invokeMethod($behavior, 'getLeftValue'),
+            "New cached left value should be '1' for root.",
+        );
+        self::assertEquals(
+            2,
+            Assert::invokeMethod($behavior, 'getRightValue'),
+            "New cached right value should be '2' for root.",
+        );
+        self::assertNotFalse(
+            $node->treeAttribute,
+            'Tree attribute should be set.',
+        );
+        self::assertNotNull(
+            $node->getAttribute($node->treeAttribute),
+            "Tree attribute should be set after 'afterInsert()'.",
+        );
+        self::assertNotNull(
+            $node->owner,
+            "Node owner should not be null after 'makeRoot()'.",
+        );
+        self::assertEquals(
+            $node->owner->getPrimaryKey(),
+            $node->getAttribute($node->treeAttribute),
+            'Tree attribute should equal primary key for root node.',
+        );
+    }
+
+    public function testCacheInvalidationAfterInsertWithoutTreeAttribute(): void
+    {
+        $this->createDatabase();
+
+        $node = new Tree(['name' => 'Root Node']);
+
+        $behavior = $node->getBehavior('nestedSetsBehavior');
+
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the node.',
+        );
+
+        $node->makeRoot();
+
+        Assert::invokeMethod($behavior, 'getDepthValue');
+        Assert::invokeMethod($behavior, 'getLeftValue');
+        Assert::invokeMethod($behavior, 'getRightValue');
+
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated after access.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated after access.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated after access.',
+        );
+
+        $node->invalidateCache();
+
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be invalidated after 'invalidateCache()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be invalidated after 'invalidateCache()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be invalidated after 'invalidateCache()'.",
+        );
+        self::assertEquals(
+            0,
+            Assert::invokeMethod($behavior, 'getDepthValue'),
+            "New cached depth value should be '0' for root.",
+        );
+        self::assertEquals(
+            1,
+            Assert::invokeMethod($behavior, 'getLeftValue'),
+            "New cached left value should be '1' for root.",
+        );
+        self::assertEquals(
+            2,
+            Assert::invokeMethod($behavior, 'getRightValue'),
+            "New cached right value should be '2' for root.",
+        );
+    }
+
+    public function testAfterInsertCallsInvalidateCache(): void
+    {
+        $this->createDatabase();
+
+        $node = new ExtendableMultipleTree(['name' => 'Root Node']);
+
+        $behavior = $node->getBehavior('nestedSetsBehavior');
+
+        self::assertInstanceOf(
+            ExtendableNestedSetsBehavior::class,
+            $behavior,
+            "'ExtendableMultipleTree' should use 'ExtendableNestedSetsBehavior'.",
+        );
+
+        $node->makeRoot();
+
+        self::assertTrue(
+            $behavior->invalidateCacheCalled,
+            "'invalidateCache()' should be called during 'afterInsert()'.",
+        );
+        self::assertNotFalse(
+            $node->treeAttribute,
+            'Tree attribute should be set.',
+        );
+        self::assertNotNull(
+            $node->getAttribute($node->treeAttribute),
+            "Tree attribute should be set after 'afterInsert()'.",
+        );
+        self::assertEquals(
+            $node->getPrimaryKey(),
+            $node->getAttribute($node->treeAttribute),
+            'Tree attribute should equal primary key for root node.',
+        );
+    }
+
+    public function testAfterInsertCacheInvalidationIntegration(): void
+    {
+        $this->createDatabase();
+
+        $root = new MultipleTree(['name' => 'Original Root']);
+
+        $root->makeRoot();
+
+        $child = new MultipleTree(['name' => 'Child Node']);
+
+        $child->appendTo($root);
+
+        $behavior = $child->getBehavior('nestedSetsBehavior');
+
+        self::assertNotNull(
+            $behavior,
+            'Behavior should be attached to the child node.',
+        );
+        self::assertEquals(
+            1,
+            $child->getAttribute('depth'),
+            "Child should start at depth '1'.",
+        );
+        self::assertEquals(
+            2,
+            $child->getAttribute('lft'),
+            "Child should start with 'lft=2'.",
+        );
+        self::assertEquals(
+            3,
+            $child->getAttribute('rgt'),
+            "Child should start with 'rgt=3'.",
+        );
+
+        Assert::invokeMethod($behavior, 'getDepthValue');
+        Assert::invokeMethod($behavior, 'getLeftValue');
+        Assert::invokeMethod($behavior, 'getRightValue');
+
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            'Depth value cache should be populated.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            'Left value cache should be populated.',
+        );
+        self::assertNotNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            'Right value cache should be populated.',
+        );
+
+        $child->makeRoot();
+
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'depthValue'),
+            "Depth value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'leftValue'),
+            "Left value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
+        );
+        self::assertNull(
+            Assert::inaccessibleProperty($behavior, 'rightValue'),
+            "Right value cache should be invalidated after 'makeRoot()'/'afterInsert()'.",
+        );
+        self::assertEquals(
+            0,
+            $child->getAttribute('depth'),
+            "Child should be at depth '0' after becoming root.",
+        );
+        self::assertEquals(
+            1,
+            $child->getAttribute('lft'),
+            "Child should have 'lft=1' after becoming root.",
+        );
+        self::assertEquals(
+            2,
+            $child->getAttribute('rgt'),
+            "Child should have 'rgt=2' after becoming root.",
+        );
+        self::assertEquals(
+            0,
+            Assert::invokeMethod($behavior, 'getDepthValue'),
+            "New cached depth should be '0'.",
+        );
+        self::assertEquals(
+            1,
+            Assert::invokeMethod($behavior, 'getLeftValue'),
+            "New cached left should be '1'.",
+        );
+        self::assertEquals(
+            2,
+            Assert::invokeMethod($behavior, 'getRightValue'),
+            "New cached right should be '2'.",
+        );
     }
 }

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2665,6 +2665,34 @@ final class NestedSetsBehaviorTest extends TestCase
         $this->verifyCacheInvalidation($behavior);
     }
 
+    public function testAfterUpdateCacheInvalidationWhenMakeRootAndNodeItsNull(): void
+    {
+        $this->createDatabase();
+
+        $root = new ExtendableMultipleTree(['name' => 'Root']);
+
+        $root->makeRoot();
+
+        $child = new ExtendableMultipleTree(['name' => 'Child']);
+
+        $child->appendTo($root);
+
+        $behavior = $child->getBehavior('nestedSetsBehavior');
+
+        self::assertInstanceOf(
+            ExtendableNestedSetsBehavior::class,
+            $behavior,
+            "'ExtendableMultipleTree' should use 'ExtendableNestedSetsBehavior'.",
+        );
+
+        $this->populateAndVerifyCache($behavior);
+
+        $behavior->setNode(null);
+        $behavior->afterUpdate();
+
+        $this->verifyCacheInvalidation($behavior);
+    }
+
     /**
      * @phpstan-param Behavior<ActiveRecord> $behavior
      */

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2637,6 +2637,34 @@ final class NestedSetsBehaviorTest extends TestCase
         );
     }
 
+    public function testAfterUpdateCacheInvalidationWhenMakeRoot(): void
+    {
+        $this->createDatabase();
+
+        $root = new ExtendableMultipleTree(['name' => 'Root']);
+
+        $root->makeRoot();
+
+        $child = new ExtendableMultipleTree(['name' => 'Child']);
+
+        $child->appendTo($root);
+
+        $behavior = $child->getBehavior('nestedSetsBehavior');
+
+        self::assertInstanceOf(
+            ExtendableNestedSetsBehavior::class,
+            $behavior,
+            "'ExtendableMultipleTree' should use 'ExtendableNestedSetsBehavior'.",
+        );
+
+        $this->populateAndVerifyCache($behavior);
+
+        $behavior->setOperation(NestedSetsBehavior::OPERATION_MAKE_ROOT);
+        $behavior->afterUpdate();
+
+        $this->verifyCacheInvalidation($behavior);
+    }
+
     /**
      * @phpstan-param Behavior<ActiveRecord> $behavior
      */

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -14,6 +14,8 @@ use yii2\extensions\nestedsets\NestedSetsBehavior;
  */
 final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
 {
+    public bool $invalidateCacheCalled = false;
+
     /**
      * @phpstan-var array<string, bool>
      */
@@ -44,7 +46,6 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
     {
         $this->calledMethods['moveNode'] = true;
 
-        // Create a mock context for testing compatibility
         $context = new \yii2\extensions\nestedsets\NodeContext(
             $node,
             0,
@@ -83,5 +84,12 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
     public function getCalledMethods(): array
     {
         return $this->calledMethods;
+    }
+
+    public function invalidateCache(): void
+    {
+        $this->invalidateCacheCalled = true;
+
+        parent::invalidateCache();
     }
 }

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -93,6 +93,11 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
         parent::invalidateCache();
     }
 
+    public function setNode(ActiveRecord|null $node): void
+    {
+        $this->node = $node;
+    }
+
     public function setOperation(string|null $operation): void
     {
         $this->operation = $operation;

--- a/tests/support/stub/ExtendableNestedSetsBehavior.php
+++ b/tests/support/stub/ExtendableNestedSetsBehavior.php
@@ -92,4 +92,9 @@ final class ExtendableNestedSetsBehavior extends NestedSetsBehavior
 
         parent::invalidateCache();
     }
+
+    public function setOperation(string|null $operation): void
+    {
+        $this->operation = $operation;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a method to manually invalidate cached values in the nested sets behavior, ensuring data consistency after tree modifications.

* **Bug Fixes**
  * Improved cache management to automatically clear outdated values after insert, update, or delete operations in the tree structure.

* **Tests**
  * Introduced comprehensive tests to verify proper cache invalidation after various tree operations and manual invalidation.
  * Added tracking to confirm cache invalidation method calls during lifecycle events.

* **Chores**
  * Added a new development dependency for enhanced support in development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->