### PR TITLE
test: Add boundary tests for `isChildOf()` method in `NestedSetsBehavior` class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "infection/infection": "^0.27|^0.29",
+        "infection/infection": "^0.27|^0.30",
         "maglnet/composer-require-checker": "^4.1",
         "php-forge/support": "^0.1",
         "phpstan/extension-installer": "^1.4",

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1395,8 +1395,8 @@ final class NestedSetsBehaviorTest extends TestCase
         $parentNode = Tree::findOne(2);
         $childNode = Tree::findOne(3);
 
-        self::assertNotNull($parentNode, "Parent node should exist for boundary testing.");
-        self::assertNotNull($childNode, "Child node should exist for boundary testing.");
+        self::assertNotNull($parentNode, 'Parent node should exist for boundary testing.');
+        self::assertNotNull($childNode, 'Child node should exist for boundary testing.');
 
         $originalChildLeft = $childNode->getAttribute('lft');
 
@@ -1405,7 +1405,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertFalse(
             $childNode->isChildOf($parentNode),
-            "Node should not be child when left values are equal (tests <= condition)."
+            'Node should not be child when left values are equal (tests <= condition).'
         );
 
         $childNode->setAttribute('lft', $originalChildLeft);
@@ -1418,8 +1418,8 @@ final class NestedSetsBehaviorTest extends TestCase
         $parentNode = Tree::findOne(2);
         $childNode = Tree::findOne(3);
 
-        self::assertNotNull($parentNode, "Parent node should exist for boundary testing.");
-        self::assertNotNull($childNode, "Child node should exist for boundary testing.");
+        self::assertNotNull($parentNode, 'Parent node should exist for boundary testing.');
+        self::assertNotNull($childNode, 'Child node should exist for boundary testing.');
 
         $originalChildRight = $childNode->getAttribute('rgt');
 
@@ -1428,7 +1428,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertFalse(
             $childNode->isChildOf($parentNode),
-            "Node should not be child when right values are equal (tests >= condition)."
+            'Node should not be child when right values are equal (tests >= condition).'
         );
 
         $childNode->setAttribute('rgt', $originalChildRight);

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1388,6 +1388,52 @@ final class NestedSetsBehaviorTest extends TestCase
         );
     }
 
+    public function testIsChildOfReturnsFalseWhenLeftValuesAreEqual(): void
+    {
+        $this->generateFixtureTree();
+
+        $parentNode = Tree::findOne(2);
+        $childNode = Tree::findOne(3);
+
+        self::assertNotNull($parentNode, "Parent node should exist for boundary testing.");
+        self::assertNotNull($childNode, "Child node should exist for boundary testing.");
+
+        $originalChildLeft = $childNode->getAttribute('lft');
+
+        $parentLeft = $parentNode->getAttribute('lft');
+        $childNode->setAttribute('lft', $parentLeft);
+
+        self::assertFalse(
+            $childNode->isChildOf($parentNode),
+            "Node should not be child when left values are equal (tests <= condition)."
+        );
+
+        $childNode->setAttribute('lft', $originalChildLeft);
+    }
+
+    public function testIsChildOfReturnsFalseWhenRightValuesAreEqual(): void
+    {
+        $this->generateFixtureTree();
+
+        $parentNode = Tree::findOne(2);
+        $childNode = Tree::findOne(3);
+
+        self::assertNotNull($parentNode, "Parent node should exist for boundary testing.");
+        self::assertNotNull($childNode, "Child node should exist for boundary testing.");
+
+        $originalChildRight = $childNode->getAttribute('rgt');
+
+        $parentRight = $parentNode->getAttribute('rgt');
+        $childNode->setAttribute('rgt', $parentRight);
+
+        self::assertFalse(
+            $childNode->isChildOf($parentNode),
+            "Node should not be child when right values are equal (tests >= condition)."
+        );
+
+        $childNode->setAttribute('rgt', $originalChildRight);
+    }
+
     public function testIsLeafReturnsTrueForLeafAndFalseForRoot(): void
     {
         $this->generateFixtureTree();

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -1405,7 +1405,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertFalse(
             $childNode->isChildOf($parentNode),
-            'Node should not be child when left values are equal (tests <= condition).'
+            'Node should not be child when left values are equal (tests <= condition).',
         );
 
         $childNode->setAttribute('lft', $originalChildLeft);
@@ -1428,7 +1428,7 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertFalse(
             $childNode->isChildOf($parentNode),
-            'Node should not be child when right values are equal (tests >= condition).'
+            'Node should not be child when right values are equal (tests >= condition).',
         );
 
         $childNode->setAttribute('rgt', $originalChildRight);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify that nodes with equal left or right values are not considered child nodes in boundary conditions.
* **Chores**
  * Updated a development dependency to support a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->