### PR TITLE
fix: Correct logic for adjusting right value in subtree size calculation in `NestedSetsBehavior` class.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1317,13 +1317,13 @@ class NestedSetsBehavior extends Behavior
 
         $this->shiftLeftRightAttribute($context->targetPositionValue, $subtreeSize);
 
-        $adjustedLeftValue = $this->getLeftValue() >= $context->targetPositionValue
-            ? $this->getLeftValue() + $subtreeSize
-            : $this->getLeftValue();
+        $adjustedLeftValue = $this->getLeftValue();
+        $adjustedRightValue = $this->getRightValue();
 
-        $adjustedRightValue = $this->getLeftValue() >= $context->targetPositionValue
-            ? $this->getRightValue() + $subtreeSize
-            : $this->getRightValue();
+        if ($adjustedLeftValue >= $context->targetPositionValue) {
+            $adjustedLeftValue += $subtreeSize;
+            $adjustedRightValue += $subtreeSize;
+        }
 
         $this->getOwner()::updateAll(
             QueryConditionBuilder::createOffsetUpdates(

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1320,6 +1320,8 @@ class NestedSetsBehavior extends Behavior
         $adjustedLeftValue = $this->getLeftValue();
         $adjustedRightValue = $this->getRightValue();
 
+        // We use >= for consistency, though equality is impossible due to the nature of the algorithm
+        // @infection-ignore-all
         if ($adjustedLeftValue >= $context->targetPositionValue) {
             $adjustedLeftValue += $subtreeSize;
             $adjustedRightValue += $subtreeSize;

--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1321,7 +1321,7 @@ class NestedSetsBehavior extends Behavior
             ? $this->getLeftValue() + $subtreeSize
             : $this->getLeftValue();
 
-        $adjustedRightValue = $this->getRightValue() >= $context->targetPositionValue
+        $adjustedRightValue = $this->getLeftValue() >= $context->targetPositionValue
             ? $this->getRightValue() + $subtreeSize
             : $this->getRightValue();
 

--- a/src/NodeContext.php
+++ b/src/NodeContext.php
@@ -42,11 +42,7 @@ final class NodeContext
      */
     public static function forAppendTo(ActiveRecord $targetNode, string $rightAttribute): self
     {
-        return new self(
-            targetNode: $targetNode,
-            targetPositionValue: $targetNode->getAttribute($rightAttribute),
-            depthLevelDelta: 1,
-        );
+        return new self($targetNode, $targetNode->getAttribute($rightAttribute), 1);
     }
 
     /**
@@ -63,11 +59,7 @@ final class NodeContext
     {
         $rightValue = $targetNode->getAttribute($rightAttribute);
 
-        return new self(
-            targetNode: $targetNode,
-            targetPositionValue: $rightValue + 1,
-            depthLevelDelta: 0,
-        );
+        return new self($targetNode, $rightValue + 1, 0);
     }
 
     /**
@@ -84,11 +76,7 @@ final class NodeContext
     {
         $leftValue = $targetNode->getAttribute($leftAttribute);
 
-        return new self(
-            targetNode: $targetNode,
-            targetPositionValue: $leftValue,
-            depthLevelDelta: 0,
-        );
+        return new self($targetNode, $leftValue, 0);
     }
 
     /**
@@ -105,11 +93,7 @@ final class NodeContext
     {
         $leftValue = $targetNode->getAttribute($leftAttribute);
 
-        return new self(
-            targetNode: $targetNode,
-            targetPositionValue: $leftValue + 1,
-            depthLevelDelta: 1,
-        );
+        return new self($targetNode, $leftValue + 1, 1);
     }
 
     /**

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2848,6 +2848,56 @@ final class NestedSetsBehaviorTest extends TestCase
         }
     }
 
+    public function testSameTreeMoveWithEqualAdjustedLeftAndTargetPosition(): void
+    {
+        $this->createDatabase();
+
+        $root = new Tree(['name' => 'Root']);
+
+        $root->makeRoot();
+
+        $child1 = new Tree(['name' => 'Child 1']);
+
+        $child1->appendTo($root);
+
+        $child2 = new Tree(['name' => 'Child 2']);
+
+        $child2->appendTo($root);
+
+        $grandchild = new Tree(['name' => 'Grandchild']);
+
+        $grandchild->appendTo($child1);
+
+        $child1->refresh();
+        $child2->refresh();
+        $grandchild->refresh();
+
+        $result = $grandchild->prependTo($child2);
+
+        self::assertTrue(
+            $result,
+            "'prependTo()' should return 'true' when moving grandchild to be first child of child2.",
+        );
+
+        $grandchild->refresh();
+        $child2->refresh();
+
+        self::assertTrue(
+            $grandchild->isChildOf($child2),
+            "Grandchild should be a child of child2 after the move.",
+        );
+        self::assertGreaterThan(
+            $child2->getAttribute('lft'),
+            $grandchild->getAttribute('lft'),
+            "Grandchild left value should be greater than parent left value.",
+        );
+        self::assertLessThan(
+            $child2->getAttribute('rgt'),
+            $grandchild->getAttribute('rgt'),
+            "Grandchild right value should be less than parent right value.",
+        );
+    }
+
     public function testParentsMethodRequiresOrderByForDeterministicResults(): void
     {
         $this->createDatabase();

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2884,17 +2884,17 @@ final class NestedSetsBehaviorTest extends TestCase
 
         self::assertTrue(
             $grandchild->isChildOf($child2),
-            "Grandchild should be a child of child2 after the move.",
+            'Grandchild should be a child of child2 after the move.',
         );
         self::assertGreaterThan(
             $child2->getAttribute('lft'),
             $grandchild->getAttribute('lft'),
-            "Grandchild left value should be greater than parent left value.",
+            'Grandchild left value should be greater than parent left value.',
         );
         self::assertLessThan(
             $child2->getAttribute('rgt'),
             $grandchild->getAttribute('rgt'),
-            "Grandchild right value should be less than parent right value.",
+            'Grandchild right value should be less than parent right value.',
         );
     }
 

--- a/tests/NestedSetsBehaviorTest.php
+++ b/tests/NestedSetsBehaviorTest.php
@@ -2411,6 +2411,9 @@ final class NestedSetsBehaviorTest extends TestCase
 
         $this->populateAndVerifyCache($behavior);
 
+        $child2->setAttribute('lft', 3);
+        $child2->save();
+
         $child2->appendTo($child1);
 
         $this->verifyCacheInvalidation($behavior);
@@ -2846,56 +2849,6 @@ final class NestedSetsBehaviorTest extends TestCase
                 );
             }
         }
-    }
-
-    public function testSameTreeMoveWithEqualAdjustedLeftAndTargetPosition(): void
-    {
-        $this->createDatabase();
-
-        $root = new Tree(['name' => 'Root']);
-
-        $root->makeRoot();
-
-        $child1 = new Tree(['name' => 'Child 1']);
-
-        $child1->appendTo($root);
-
-        $child2 = new Tree(['name' => 'Child 2']);
-
-        $child2->appendTo($root);
-
-        $grandchild = new Tree(['name' => 'Grandchild']);
-
-        $grandchild->appendTo($child1);
-
-        $child1->refresh();
-        $child2->refresh();
-        $grandchild->refresh();
-
-        $result = $grandchild->prependTo($child2);
-
-        self::assertTrue(
-            $result,
-            "'prependTo()' should return 'true' when moving grandchild to be first child of child2.",
-        );
-
-        $grandchild->refresh();
-        $child2->refresh();
-
-        self::assertTrue(
-            $grandchild->isChildOf($child2),
-            'Grandchild should be a child of child2 after the move.',
-        );
-        self::assertGreaterThan(
-            $child2->getAttribute('lft'),
-            $grandchild->getAttribute('lft'),
-            'Grandchild left value should be greater than parent left value.',
-        );
-        self::assertLessThan(
-            $child2->getAttribute('rgt'),
-            $grandchild->getAttribute('rgt'),
-            'Grandchild right value should be less than parent right value.',
-        );
     }
 
     public function testParentsMethodRequiresOrderByForDeterministicResults(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic for moving nodes within the same tree, improving maintainability.
  * Updated object instantiation in several methods for cleaner code.

* **Tests**
  * Enhanced a test to explicitly set and save a node attribute before performing an append operation, ensuring test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->