### PR TITLE
fix: simplify root node insertion check in `beforeInsertRootNode` method.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -1070,10 +1070,7 @@ class NestedSetsBehavior extends Behavior
      */
     protected function beforeInsertRootNode(): void
     {
-        if (
-            $this->treeAttribute === false &&
-            $this->getOwner()::find()->andWhere([$this->leftAttribute => 1])->exists()
-        ) {
+        if ($this->treeAttribute === false && $this->getOwner()::find()->exists()) {
             throw new Exception('Can not create more than one root when "treeAttribute" is false.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
