### PR TITLE
refactor: Remove unnecessary ordering by `lft` attribute in query.

### DIFF
--- a/src/NestedSetsBehavior.php
+++ b/src/NestedSetsBehavior.php
@@ -495,10 +495,6 @@ class NestedSetsBehavior extends Behavior
                     $depth !== null ? $this->getDepthValue() : null,
                     $depth,
                 ),
-            )->addOrderBy(
-                [
-                    $this->leftAttribute => SORT_ASC,
-                ],
             );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
