### PR TITLE
fix: Remove unused command coverage options from mutation workflow configuration.

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -72,7 +72,6 @@ jobs:
         echo "PGSQL_DSN=pgsql:host=localhost;port=5432;dbname=yiitest" >> $GITHUB_ENV
         echo "PGSQL_USERNAME=root" >> $GITHUB_ENV
         echo "PGSQL_PASSWORD=root" >> $GITHUB_ENV
-      command-coverage-options: --with-uncovered
       extensions: pdo, pdo_mysql, pdo_pgsql, pdo_sqlite
       framework-options: --test-framework-options="--group=sqlite,mutation"
       phpstan: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #85: Update license badge URL in `README.md` and add license header in `LICENSE.md` and kill infection mutant (@terabytesoftw)
 - Bug #87: Update `.gitattributes` to exclude additional files from the package, update `LICENSE.md` and add stable version worflows actions (@terabytesoftw)
+- Bug #88: Remove unused command coverage options from mutation workflow configuration (@terabytesoftw)
 
 ## 0.1.0 July 8, 2025
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
